### PR TITLE
Provision cloud foundry secrets in `make setup`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,23 @@ set-pipelines:
 		--var concourse-username=test \
 		--var concourse-password=test \
 		--non-interactive
+	fly -t local-pay unpause-pipeline -p provision-dev-envs
 
-setup: start-concourse login create-team login-team set-pipelines
+add-creds:
+	 docker-compose exec localstack \
+		 awslocal ssm put-parameter \
+		 --name /concourse/pay/cf-username \
+		 --value $$(env PASSWORD_STORE_DIR=secrets pass paas-london/govuk-pay/org-manager-bot/username) \
+		 --type String \
+		 --overwrite
+	 docker-compose exec localstack \
+		 awslocal ssm put-parameter \
+		 --name /concourse/pay/cf-password \
+		 --value $$(env PASSWORD_STORE_DIR=secrets pass paas-london/govuk-pay/org-manager-bot/password) \
+		 --type String \
+		 --overwrite
+
+setup: start-concourse add-creds login create-team login-team set-pipelines
 	
 destroy:
 	docker-compose down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,6 @@ services:
 
   localstack:
     image: localstack/localstack
-    ports: ["4583:4583"]
     environment:
       SERVICES: ssm
     networks:


### PR DESCRIPTION
Now that we've got SSM running locally, we can push secrets into it from
the secrets store for use in the pipelines.