### PR TITLE
Add selenium and card smoke-test pipelines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,8 @@ add-creds:
 	secrets/local-ssm-add.sh /concourse/pay-deploy/cf-password paas-london/govuk-pay/org-manager-bot/password
 	secrets/local-ssm-add.sh /concourse/pay-deploy/gh-username github/readonly-user/username
 	secrets/local-ssm-add.sh /concourse/pay-deploy/gh-password github/readonly-user/password
+	secrets/local-ssm-add.sh /concourse/pay-deploy/dh-username docker/readonly-user/username
+	secrets/local-ssm-add.sh /concourse/pay-deploy/dh-password docker/readonly-user/password
 
 setup: start-concourse add-creds login create-team login-team set-pipelines
 	

--- a/ci/pipelines/selenium-hub.yml
+++ b/ci/pipelines/selenium-hub.yml
@@ -10,7 +10,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/pay-omnibus
-      branch: skeleton_smoke_tests
+      branch: smoke_tests
 
   - name: paas-tools
     type: cf-cli

--- a/ci/pipelines/selenium-hub.yml
+++ b/ci/pipelines/selenium-hub.yml
@@ -26,15 +26,41 @@ jobs:
     plan:
       - get: omnibus
       - in_parallel:
-        - put: cf-push
+        - put: cf-push selenium-hub
           resource: paas-tools
           params:
             command: push
             app_name: selenium-hub
             manifest: omnibus/paas/selenium-apps.yml
-        - put: cf-push
+        - put: cf-push chrome
           resource: paas-tools
           params:
             command: push
             app_name: chrome
             manifest: omnibus/paas/selenium-apps.yml
+  - name: start-selenium
+    plan:
+      - in_parallel:
+        - put: start selenium hub
+          resource: paas-tools
+          params:
+            command: start
+            app_name: selenium-hub
+        - put: start chrome
+          resource: paas-tools
+          params:
+            command: start
+            app_name: chrome
+  - name: stop-selenium
+    plan:
+      - in_parallel:
+        - put: stop selenium hub
+          resource: paas-tools
+          params:
+            command: stop
+            app_name: selenium-hub
+        - put: stop chrome
+          resource: paas-tools
+          params:
+            command: stop
+            app_name: chrome

--- a/ci/pipelines/selenium-hub.yml
+++ b/ci/pipelines/selenium-hub.yml
@@ -1,0 +1,40 @@
+---
+resource_types:
+  - name: cf-cli
+    type: docker-image
+    source:
+      repository: nulldriver/cf-cli-resource
+
+resources:
+  - name: omnibus
+    type: git
+    source:
+      uri: https://github.com/alphagov/pay-omnibus
+      branch: skeleton_smoke_tests
+
+  - name: paas-tools
+    type: cf-cli
+    source:
+      api: https://api.london.cloud.service.gov.uk
+      org: govuk-pay
+      space: tools
+      username: ((cf-username))
+      password: ((cf-password))
+
+jobs:
+  - name: deploy-selenium-hub
+    plan:
+      - get: omnibus
+      - in_parallel:
+        - put: cf-push
+          resource: paas-tools
+          params:
+            command: push
+            app_name: selenium-hub
+            manifest: omnibus/paas/selenium-apps.yml
+        - put: cf-push
+          resource: paas-tools
+          params:
+            command: push
+            app_name: chrome
+            manifest: omnibus/paas/selenium-apps.yml

--- a/ci/pipelines/smoke-tests.yml
+++ b/ci/pipelines/smoke-tests.yml
@@ -1,0 +1,34 @@
+---
+groups:
+  - name: Smoke Tests
+    jobs:
+      - card-smoke-test
+
+resources:
+  - name: every-10m
+    type: time
+    source: { interval: 10m }
+
+  - name: omnibus
+    type: git
+    source:
+      uri: https://github.com/alphagov/pay-omnibus
+      branch: smoke_tests
+
+jobs:
+  - name: card-smoke-test
+    serial: true
+    plan:
+      - get: every-10m
+        trigger: true
+      - get: omnibus
+      - task: test
+        file: omnibus/ci/tasks/run-smoke-test.yml
+        params:
+          SMOKE_TEST: smoke-card
+          SELENIUM_HUB_URL: pay-selenium-hub.london.cloudapps.digital
+          SMOKE_TEST_PRODUCT_PAYMENT_LINK_URL: https://products.pymnt.uk/redirect/smoke-test/product-test-environment
+
+
+
+  

--- a/ci/pipelines/smoke-tests.yml
+++ b/ci/pipelines/smoke-tests.yml
@@ -26,7 +26,7 @@ jobs:
         file: omnibus/ci/tasks/run-smoke-test.yml
         params:
           SMOKE_TEST: smoke-card
-          SELENIUM_HUB_URL: pay-selenium-hub.london.cloudapps.digital
+          SELENIUM_HUB_URL: https://pay-selenium-hub.london.cloudapps.digital
           SMOKE_TEST_PRODUCT_PAYMENT_LINK_URL: https://products.pymnt.uk/redirect/smoke-test/product-test-environment
 
 

--- a/ci/tasks/run-smoke-test.yml
+++ b/ci/tasks/run-smoke-test.yml
@@ -24,6 +24,6 @@ run:
   args:
     - -c
     - |
-    - set -ue
-    - /app/bin/${SMOKE_TEST}
+      set -ue
+      /app/bin/${SMOKE_TEST}
   

--- a/ci/tasks/run-smoke-test.yml
+++ b/ci/tasks/run-smoke-test.yml
@@ -1,0 +1,29 @@
+# Runs smoke tests in a Concourse task using endtoend docker container
+# See: https://github.com/alphagov/pay-scripts/blob/master/jenkins/run-smoke.sh
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: govukpay/endtoend
+    tag: latest-master
+    username: ((dh-username))
+    password: ((dh-password))
+
+params:
+  SMOKE_TEST:
+  PUBLICAPI_URL:
+  SELFSERVICE_URL:
+  SELENIUM_HUB_URL:
+  WEB_DRIVER: CHROME_REMOTE
+  CHROME_DRIVER_PATH: /usr/bin/chromedriver
+  HTTP_ZAP_ENABLED: 'false'
+
+run:
+  path: sh
+  args:
+    - -c
+    - |
+    - set -ue
+    - /app/bin/${SMOKE_TEST}
+  

--- a/paas/selenium-apps.yml
+++ b/paas/selenium-apps.yml
@@ -1,0 +1,32 @@
+---
+applications:
+  - name: selenium-hub
+    docker:
+      image: selenium/hub:3.141.59
+    health-check-type: process
+    memory: 1G
+    instances: 1
+    env:
+      JAVA_OPTS: "-Xmx640M"
+      GRID_HUB_PORT: 4444
+      GRID_BROWSER_TIMEOUT: 60
+      GRID_DEBUG: false
+    routes:
+    - route: pay-selenium-hub.london.cloudapps.digital
+    - route: selenium-hub.apps.internal
+  - name: chrome
+    docker:
+      image: selenium/node-chrome:3.141.59
+    health-check-type: process
+    memory: 2G
+    instances: 1
+    env:
+      HUB_HOST: selenium-hub.apps.internal
+      HUB_PORT: 4444
+      NODE_MAX_INSTANCES: 4
+      NODE_MAX_SESSION: 4
+      START_XVFB: false
+      JAVA_OPTS: "-Xmx1280M"
+      GRID_DEBUG: false
+    routes:
+    - route: chrome.apps.internal


### PR DESCRIPTION
Adds:

* `selenium-hub` pipeline - Deploys a persistent Selenium hub / chrome application to PaaS `tools` space 
* `smoke-tests` pipeline - Runs card smoke tests on Concourse using existing pay-endtoend docker container using selenium hub running on PaaS