### PR TITLE
Deploy apps independently of infrastructure

### DIFF
--- a/ci/pipelines/deploy-env.yml
+++ b/ci/pipelines/deploy-env.yml
@@ -115,6 +115,213 @@ jobs:
             - command: create-space
             - command: create-users-from-file
               file: out/users.csv
+      - in_parallel:
+        - &create-app
+          task: create-adminusers
+          file: omnibus/ci/tasks/create-app.yml
+          params: &create-app-params
+            CF_ORG: govuk-pay
+            CF_SPACE: ((space))
+            APP: adminusers
+        - <<: *create-app
+          task: create-cardid
+          params:
+            <<: *create-app-params
+            APP: cardid
+        - <<: *create-app
+          task: create-card-frontend
+          params:
+            <<: *create-app-params
+            APP: card-frontend
+        - <<: *create-app
+          task: create-card-connector
+          params:
+            <<: *create-app-params
+            APP: card-connector
+        - <<: *create-app
+          task: create-directdebit-frontend
+          params:
+            <<: *create-app-params
+            APP: directdebit-frontend
+        - <<: *create-app
+          task: create-directdebit-connector
+          params:
+            <<: *create-app-params
+            APP: directdebit-connector
+        - <<: *create-app
+          task: create-ledger
+          params:
+            <<: *create-app-params
+            APP: ledger
+        - <<: *create-app
+          task: create-products
+          params:
+            <<: *create-app-params
+            APP: products
+        - <<: *create-app
+          task: create-products-ui
+          params:
+            <<: *create-app-params
+            APP: products-ui
+        - <<: *create-app
+          task: create-publicapi
+          params:
+            <<: *create-app-params
+            APP: publicapi
+        - <<: *create-app
+          task: create-publicauth
+          params:
+            <<: *create-app-params
+            APP: publicauth
+        - <<: *create-app
+          task: create-selfservice
+          params:
+            <<: *create-app-params
+            APP: selfservice
+        - <<: *create-app
+          task: create-egress
+          params:
+            <<: *create-app-params
+            APP: egress
+        - <<: *create-app
+          task: create-postgres
+          params:
+            <<: *create-app-params
+            APP: postgres
+        - <<: *create-app
+          task: create-sqs
+          params:
+            <<: *create-app-params
+            APP: sqs
+      - in_parallel:
+        - put: network-policy-adminusers-egress
+          resource: paas
+          params:
+            command: add-network-policy
+            source_app: adminusers
+            destination_app: egress
+            port: 8080
+            protocol: tcp
+        - put: network-policy-adminusers-postgres
+          resource: paas
+          params:
+            command: add-network-policy
+            source_app: adminusers
+            destination_app: postgres
+            port: 5432
+            protocol: tcp
+        - put: network-policy-card-frontend-card-connector
+          resource: paas
+          params:
+            command: add-network-policy
+            source_app: card-frontend
+            destination_app: card-connector
+            port: 8080
+            protocol: tcp
+        - put: network-policy-card-frontend-cardid
+          resource: paas
+          params:
+            command: add-network-policy
+            source_app: card-frontend
+            destination_app: cardid
+            port: 8080
+            protocol: tcp
+        - put: network-policy-card-frontend-adminusers
+          resource: paas
+          params:
+            command: add-network-policy
+            source_app: card-frontend
+            destination_app: adminusers
+            port: 8080
+            protocol: tcp
+        - put: network-policy-card-connector-egress
+          resource: paas
+          params:
+            command: add-network-policy
+            source_app: card-connector
+            destination_app: egress
+            port: 8080
+            protocol: tcp
+        - put: network-policy-card-connector-postgres
+          resource: paas
+          params:
+            command: add-network-policy
+            source_app: card-connector
+            destination_app: postgres
+            port: 5432
+            protocol: tcp
+        - put: network-policy-card-connector-sqs
+          resource: paas
+          params:
+            command: add-network-policy
+            source_app: card-connector
+            destination_app: sqs
+            port: 9324
+            protocol: tcp
+        - put: network-policy-directdebit-frontend-directdebit-connector
+          resource: paas
+          params:
+            command: add-network-policy
+            source_app: directdebit-frontend
+            destination_app: directdebit-connector
+            port: 8080
+            protocol: tcp
+        - put: network-policy-directdebit-frontend-egress
+          resource: paas
+          params:
+            command: add-network-policy
+            source_app: directdebit-frontend
+            destination_app: adminusers
+            port: 8080
+            protocol: tcp
+        - put: network-policy-directdebit-connector-egress
+          resource: paas
+          params:
+            command: add-network-policy
+            source_app: directdebit-connector
+            destination_app: egress
+            port: 8080
+            protocol: tcp
+        - put: network-policy-directdebit-connector-postgres
+          resource: paas
+          params:
+            command: add-network-policy
+            source_app: directdebit-connector
+            destination_app: postgres
+            port: 5432
+            protocol: tcp
+        - put: network-policy-publicauth-postgres
+          resource: paas
+          params:
+            command: add-network-policy
+            source_app: publicauth
+            destination_app: postgres
+            port: 5432
+            protocol: tcp
+        - put: network-policy-products-postgres
+          resource: paas
+          params:
+            command: add-network-policy
+            source_app: products
+            destination_app: postgres
+            port: 5432
+            protocol: tcp
+        - put: network-policy-ledger-postgres
+          resource: paas
+          params:
+            command: add-network-policy
+            source_app: ledger
+            destination_app: postgres
+            port: 5432
+            protocol: tcp
+        - put: network-policy-ledger-sqs
+          resource: paas
+          params:
+            command: add-network-policy
+            source_app: ledger
+            destination_app: sqs
+            port: 9324
+            protocol: tcp
 
   - name: delete-space
     plan:
@@ -136,7 +343,6 @@ jobs:
           command: push
           app_name: adminusers
           manifest: omnibus/paas/pay-apps.yml
-          no_start: true
           docker_password: ((docker-password))
           vars:
             space: ((space))
@@ -317,333 +523,3 @@ jobs:
         params:
           <<: *paas-app
           app_name: postgres
-
-  - name: adminusers-network-policies
-    plan:
-      - get: omnibus
-        passed: [deploy-adminusers, deploy-tools]
-        trigger: true
-      - put: network-policy-egress
-        resource: paas
-        params:
-          command: add-network-policy
-          source_app: adminusers
-          destination_app: egress
-          port: 8080
-          protocol: tcp
-      - put: network-policy-postgres
-        resource: paas
-        params:
-          command: add-network-policy
-          source_app: adminusers
-          destination_app: postgres
-          port: 5432
-          protocol: tcp
-
-  - name: card-connector-network-policies
-    plan:
-      - get: omnibus
-        passed: [deploy-card-connector, deploy-tools]
-        trigger: true
-      - put: network-policy-egress
-        resource: paas
-        params:
-          command: add-network-policy
-          source_app: card-connector
-          destination_app: egress
-          port: 8080
-          protocol: tcp
-      - put: network-policy-postgres
-        resource: paas
-        params:
-          command: add-network-policy
-          source_app: card-connector
-          destination_app: postgres
-          port: 5432
-          protocol: tcp
-      - put: network-policy-sqs
-        resource: paas
-        params:
-          command: add-network-policy
-          source_app: card-connector
-          destination_app: sqs
-          port: 9324
-          protocol: tcp
-
-  - name: directdebit-frontend-network-policies
-    plan:
-      - get: omnibus
-        passed: [deploy-directdebit-frontend, deploy-directdebit-connector]
-        trigger: true
-      - put: network-policy-egress
-        resource: paas
-        params:
-          command: add-network-policy
-          source_app: directdebit-frontend
-          destination_app: directdebit-connector
-          port: 8080
-          protocol: tcp
-      - put: network-policy-egress
-        resource: paas
-        params:
-          command: add-network-policy
-          source_app: directdebit-frontend
-          destination_app: adminusers
-          port: 8080
-          protocol: tcp
-
-  - name: directdebit-connector-network-policies
-    plan:
-      - get: omnibus
-        passed: [deploy-directdebit-connector, deploy-tools]
-        trigger: true
-      - put: network-policy-egress
-        resource: paas
-        params:
-          command: add-network-policy
-          source_app: directdebit-connector
-          destination_app: egress
-          port: 8080
-          protocol: tcp
-      - put: network-policy-postgres
-        resource: paas
-        params:
-          command: add-network-policy
-          source_app: directdebit-connector
-          destination_app: postgres
-          port: 5432
-          protocol: tcp
-
-  - name: card-frontend-network-policies
-    plan:
-      - get: omnibus
-        passed: [deploy-card-frontend, deploy-card-connector, deploy-cardid, deploy-adminusers]
-        trigger: true
-      - put: network-policy-card-connector
-        resource: paas
-        params:
-          command: add-network-policy
-          source_app: card-frontend
-          destination_app: card-connector
-          port: 8080
-          protocol: tcp
-      - put: network-policy-cardid
-        resource: paas
-        params:
-          command: add-network-policy
-          source_app: card-frontend
-          destination_app: cardid
-          port: 8080
-          protocol: tcp
-      - put: network-policy-adminusers
-        resource: paas
-        params:
-          command: add-network-policy
-          source_app: card-frontend
-          destination_app: adminusers
-          port: 8080
-          protocol: tcp
-
-  - name: publicauth-network-policies
-    plan:
-      - get: omnibus
-        passed: [deploy-publicauth, deploy-tools]
-        trigger: true
-      - put: network-policy-postgres
-        resource: paas
-        params:
-          command: add-network-policy
-          source_app: publicauth
-          destination_app: postgres
-          port: 5432
-          protocol: tcp
-
-  - name: products-network-policies
-    plan:
-      - get: omnibus
-        passed: [deploy-products, deploy-tools]
-        trigger: true
-      - put: network-policy-postgres
-        resource: paas
-        params:
-          command: add-network-policy
-          source_app: products
-          destination_app: postgres
-          port: 5432
-          protocol: tcp
-
-  - name: ledger-network-policies
-    plan:
-      - get: omnibus
-        passed: [deploy-ledger, deploy-tools]
-        trigger: true
-      - put: network-policy-postgres
-        resource: paas
-        params:
-          command: add-network-policy
-          source_app: ledger
-          destination_app: postgres
-          port: 5432
-          protocol: tcp
-      - put: network-policy-sqs
-        resource: paas
-        params:
-          command: add-network-policy
-          source_app: ledger
-          destination_app: sqs
-          port: 9324
-          protocol: tcp
-
-  - name: start-adminusers
-    plan:
-      - get: omnibus
-        passed: [deploy-adminusers, adminusers-network-policies]
-        trigger: true
-      - put: start-app
-        resource: paas
-        params:
-          command: start
-          app_name: adminusers
-
-  - name: start-cardid
-    plan:
-      - get: omnibus
-        passed: [deploy-cardid]
-        trigger: true
-      - put: start-app
-        resource: paas
-        params:
-          command: start
-          app_name: cardid
-
-  - name: start-card-connector
-    plan:
-      - get: omnibus
-        passed: [deploy-card-connector, card-connector-network-policies]
-        trigger: true
-      - put: start-app
-        resource: paas
-        params:
-          command: start
-          app_name: card-connector
-
-  - name: start-card-frontend
-    plan:
-      - get: omnibus
-        passed: [deploy-card-frontend, card-frontend-network-policies]
-        trigger: true
-      - put: start-app
-        resource: paas
-        params:
-          command: start
-          app_name: card-frontend
-
-  - name: start-directdebit-connector
-    plan:
-      - get: omnibus
-        passed: [deploy-directdebit-connector, directdebit-connector-network-policies]
-        trigger: true
-      - put: start-app
-        resource: paas
-        params:
-          command: start
-          app_name: directdebit-connector
-
-  - name: start-directdebit-frontend
-    plan:
-      - get: omnibus
-        passed: [deploy-directdebit-frontend, directdebit-frontend-network-policies]
-        trigger: true
-      - put: start-app
-        resource: paas
-        params:
-          command: start
-          app_name: directdebit-frontend
-
-  - name: start-ledger
-    plan:
-      - get: omnibus
-        passed: [deploy-ledger, ledger-network-policies]
-        trigger: true
-      - put: start-app
-        resource: paas
-        params:
-          command: start
-          app_name: ledger
-
-  - name: start-products
-    plan:
-      - get: omnibus
-        passed: [deploy-products, products-network-policies]
-        trigger: true
-      - put: start-app
-        resource: paas
-        params:
-          command: start
-          app_name: products
-
-  - name: start-products-ui
-    plan:
-      - get: omnibus
-        passed: [deploy-products-ui]
-        trigger: true
-      - put: start-app
-        resource: paas
-        params:
-          command: start
-          app_name: products-ui
-
-  - name: start-publicapi
-    plan:
-      - get: omnibus
-        passed: [deploy-publicapi]
-        trigger: true
-      - put: start-app
-        resource: paas
-        params:
-          command: start
-          app_name: publicapi
-
-  - name: start-publicauth
-    plan:
-      - get: omnibus
-        passed: [deploy-publicauth, publicauth-network-policies]
-        trigger: true
-      - put: start-app
-        resource: paas
-        params:
-          command: start
-          app_name: publicauth
-
-  - name: start-selfservice
-    plan:
-      - get: omnibus
-        passed: [deploy-selfservice]
-        trigger: true
-      - put: start-app
-        resource: paas
-        params:
-          command: start
-          app_name: selfservice
-
-  - name: start-tools
-    plan:
-      - get: omnibus
-        passed: [deploy-tools]
-        trigger: true
-      - put: start-egress
-        resource: paas
-        params:
-          command: start
-          app_name: egress
-      - put: start-sqs
-        resource: paas
-        params:
-          command: start
-          app_name: sqs
-      - put: start-postgres
-        resource: paas
-        params:
-          command: start
-          app_name: postgres
-

--- a/ci/tasks/create-app.yml
+++ b/ci/tasks/create-app.yml
@@ -1,0 +1,25 @@
+platform: linux
+
+image_resource:
+  type: docker-image
+  source: { repository: governmentpaas/cf-cli }
+
+params:
+  CF_USERNAME: ((cf-username))
+  CF_PASSWORD: ((cf-password))
+  ORG:
+  SPACE:
+  APP:
+  TYPE: docker
+
+run:
+  path: bash
+  args:
+    - -c
+    - |
+      set -o errexit -o nounset
+      cf login -a https://api.london.cloud.service.gov.uk \
+        -u "$CF_USERNAME" -p "$CF_PASSWORD" \
+        -o "$CF_ORG" -s "$CF_SPACE"
+      # check if app exists and create if it doesn't
+      cf app --guid "$APP" || cf v3-create-app "$APP" --app-type "$TYPE"


### PR DESCRIPTION
The `provision-space` job is now responsible for creating placeholder
apps and network policies. The app jobs just pick up changes to the
Docker images and push them to PaaS without triggering any infra
changes.

We have to push an alpine image because you can't switch between
buildpack apps (the default) and Docker image apps without deleting the
app first.