### PR TITLE
Reduce duplication in pay-apps.yaml

### DIFF
--- a/ci/pipelines/deploy-env.yml
+++ b/ci/pipelines/deploy-env.yml
@@ -347,6 +347,8 @@ jobs:
           vars:
             space: ((space))
             docker-username: ((docker-username))
+          vars_files:
+            - omnibus/paas/env_variables/((environment)).yml
 
   - name: deploy-cardid
     serial_groups: [cardid, michaelangelo]

--- a/ci/pipelines/provision-envs.yml
+++ b/ci/pipelines/provision-envs.yml
@@ -39,38 +39,46 @@ jobs:
               config_file: omnibus/ci/pipelines/deploy-env.yml
               vars:
                 space: dev-anshul
+                environment: dev
             - name: dev-env-richard
               team: pay-deploy
               config_file: omnibus/ci/pipelines/deploy-env.yml
               vars:
                 space: dev-richard
+                environment: dev
             - name: dev-env-dan
               team: pay-deploy
               config_file: omnibus/ci/pipelines/deploy-env.yml
               vars:
                 space: dev-dan
+                environment: dev
             - name: dev-env-dom
               team: pay-deploy
               config_file: omnibus/ci/pipelines/deploy-env.yml
               vars:
                 space: dev-dom
+                environment: dev
             - name: dev-env-nim
               team: pay-deploy
               config_file: omnibus/ci/pipelines/deploy-env.yml
               vars:
                 space: dev-nim
+                environment: dev
             - name: dev-env-oswald
               team: pay-deploy
               config_file: omnibus/ci/pipelines/deploy-env.yml
               vars:
                 space: dev-oswald
+                environment: dev
             - name: dev-env-stephen
               team: pay-deploy
               config_file: omnibus/ci/pipelines/deploy-env.yml
               vars:
                 space: dev-stephen
+                environment: dev
             - name: staging
               team: pay-deploy
               config_file: omnibus/ci/pipelines/deploy-env.yml
               vars:
                 space: staging
+                environment: staging

--- a/paas/env_variables/dev.yml
+++ b/paas/env_variables/dev.yml
@@ -1,0 +1,9 @@
+---
+default_memory: 500M
+default_disk_quota: 500M
+log_level: WARNING
+http_proxy_enabled: false
+run_migration: true
+http_proxy_port: '8080'
+http_proxy_host: egress-((space)).apps.internal
+disable_internal_https: true

--- a/paas/env_variables/staging.yml
+++ b/paas/env_variables/staging.yml
@@ -1,0 +1,9 @@
+---
+default_memory: 500M
+default_disk_quota: 500M
+log_level: WARNING
+http_proxy_enabled: false
+run_migration: true
+http_proxy_port: '8080'
+http_proxy_host: egress-((space)).apps.internal
+disable_internal_https: true

--- a/paas/pay-apps.yml
+++ b/paas/pay-apps.yml
@@ -5,13 +5,15 @@ applicationTemplate: &applicationTemplate
     image: template
     username: ((docker-username))
   health-check-type: process
-  memory: 1.5G
+  memory: ((default_memory))
+  disk_quota: ((default_disk_quota))
   env: &defaultEnvs
-    HTTP_PROXY_HOST: egress-((space)).apps.internal
-    HTTP_PROXY_PORT: '8080'
-    RUN_MIGRATION: 'true'
+    HTTP_PROXY_HOST: ((http_proxy_host))
+    HTTP_PROXY_PORT: ((http_proxy_port))
+    HTTP_PROXY_ENABLED: ((http_proxy_enabled))
+    RUN_MIGRATION: ((run_migration))
     RUN_APP: 'true'
-    DISABLE_INTERNAL_HTTPS: 'true'
+    DISABLE_INTERNAL_HTTPS: ((disable_internal_https))
     JAVA_OPTS: -Xms512m -Xmx1G
 
 applications:
@@ -23,8 +25,8 @@ applications:
     env:
       <<: *defaultEnvs
       ADMIN_PORT: '9701'
-      JPA_LOG_LEVEL: WARNING
-      JPA_SQL_LOG_LEVEL: WARNING
+      JPA_LOG_LEVEL: ((log_level))
+      JPA_SQL_LOG_LEVEL: ((log_level))
       DB_HOST: postgres-((space)).apps.internal
       DB_SSL_OPTION: ssl=false
       DB_USER: adminusers
@@ -90,11 +92,8 @@ applications:
       GDS_CONNECTOR_SMARTPAY_NOTIFICATION_USER: smartpay-user
       GDS_CONNECTOR_SMARTPAY_NOTIFICATION_PASSWORD: smartpay-password
       STRIPE_TRANSACTION_FEE_PERCENTAGE: '0.1'
-      JPA_LOG_LEVEL: WARNING
-      JPA_SQL_LOG_LEVEL: WARNING
-      HTTP_PROXY_ENABLED: 'false'
-      HTTP_PROXY_HOST: egress-((space)).apps.internal
-      HTTP_PROXY_PORT: '8080'
+      JPA_LOG_LEVEL: ((log_level))
+      JPA_SQL_LOG_LEVEL: ((log_level))
       HTTP_PROXY_SCHEME: http
       AUTH_READ_TIMEOUT_SECONDS: '1'
       NOTIFY_EMAIL_ENABLED: 'true'
@@ -133,16 +132,14 @@ applications:
       DB_SSL_OPTION: ssl=false
       DB_USER: directdebit_connector
       DB_PASSWORD: mysecretpassword
-      HTTP_PROXY_HOST: egress-((space)).apps.internal
-      HTTP_PROXY_PORT: '8080'
       FRONTEND_URL: https://pay-card-frontend-((space)).london.cloudapps.digital
       ADMINUSERS_URL: http://pay-adminusers-((space)).london.cloudapps.digital
       GDS_DIRECTDEBIT_CONNECTOR_GOCARDLESS_ACCESS_TOKEN: supersecret
       GDS_DIRECTDEBIT_CONNECTOR_GOCARDLESS_URL: https://pay-stubs-((space)).london.cloudapps.digital/stub/gocardless/
       GDS_DIRECTDEBIT_CONNECTOR_GOCARDLESS_WEBHOOK_SECRET: supersecret
       GDS_DIRECTDEBIT_CONNECTOR_GOCARDLESS_ENVIRONMENT: sandbox
-      JPA_LOG_LEVEL: WARNING
-      JPA_SQL_LOG_LEVEL: WARNING
+      JPA_LOG_LEVEL: ((log_level))
+      JPA_SQL_LOG_LEVEL: ((log_level))
       AUTH_READ_TIMEOUT_SECONDS: '1'
       GOCARDLESS_TEST_CLIENT_ID: gocardless-test-oauth-client-id
       GOCARDLESS_TEST_CLIENT_SECRET: gocardless-test-oauth-client-secret
@@ -232,16 +229,14 @@ applications:
       DB_SSL_OPTION: ssl=false
       DB_USER: products
       DB_PASSWORD: mysecretpassword
-      JPA_LOG_LEVEL: WARNING
-      JPA_SQL_LOG_LEVEL: WARNING
+      JPA_LOG_LEVEL: ((log_level))
+      JPA_SQL_LOG_LEVEL: ((log_level))
       PUBLICAPI_URL: https://pay-publicapi-((space)).london.cloudapps.digital
       BASE_URL: https://pay-products-((space)).london.cloudapps.digital
       PRODUCTS_API_TOKEN: g0nBA5lNzfUalQjk4ZBDy70AikNshxz2G70dA6lg
       PRODUCTSUI_PAY_URL: https://pay-products-ui-((space)).london.cloudapps.digital/pay
       PRODUCTSUI_CONFIRMATION_URL: https://pay-products-ui-((space)).london.cloudapps.digital/payment-complete
       PRODUCTS_FRIENDLY_BASE_URI: https://pay-products-ui-((space)).london.cloudapps.digital/redirect
-      HTTP_PROXY_HOST: postgres-((space)).apps.internal
-      HTTP_PROXY_PORT: '8080'
       AWS_XRAY_CONTEXT_MISSING: LOG_ERROR
     routes:
     - route: pay-products-((space)).london.cloudapps.digital
@@ -316,7 +311,6 @@ applications:
       COOKIE_MAX_AGE: '10800000'
       NODE_WORKER_COUNT: '1'
       PGSSLMODE: verify-full
-      HTTP_PROXY_ENABLED: 'false'
       AWS_XRAY_DAEMON_ADDRESS: xray:2000
       EPDQ_3DS_ENABLED: 'true'
       SMARTPAY_3DS_ENABLED: 'true'

--- a/paas/pay-apps.yml
+++ b/paas/pay-apps.yml
@@ -1,22 +1,35 @@
 ---
+applicationTemplate: &applicationTemplate
+  name: template
+  docker: &dockerImage
+    image: template
+    username: ((docker-username))
+  health-check-type: process
+  memory: 1.5G
+  env: &defaultEnvs
+    HTTP_PROXY_HOST: egress-((space)).apps.internal
+    HTTP_PROXY_PORT: '8080'
+    RUN_MIGRATION: 'true'
+    RUN_APP: 'true'
+    DISABLE_INTERNAL_HTTPS: 'true'
+    JAVA_OPTS: -Xms512m -Xmx1G
+
 applications:
-  - name: adminusers
+  - <<: *applicationTemplate
+    name: adminusers
     docker:
+      <<: *dockerImage
       image: govukpay/adminusers:latest-master
-      username: ((docker-username))
-    health-check-type: process
-    memory: 1.5G
     env:
+      <<: *defaultEnvs
       ADMIN_PORT: '9701'
+      JPA_LOG_LEVEL: WARNING
+      JPA_SQL_LOG_LEVEL: WARNING
       DB_HOST: postgres-((space)).apps.internal
       DB_SSL_OPTION: ssl=false
       DB_USER: adminusers
       DB_PASSWORD: mysecretpassword
-      JPA_LOG_LEVEL: WARNING
-      JPA_SQL_LOG_LEVEL: WARNING
       LOGIN_ATTEMPT_CAP: '2'
-      HTTP_PROXY_HOST: egress-((space)).apps.internal
-      HTTP_PROXY_PORT: '8080'
       NOTIFY_SERVICE_ID: pay-notify-service-id
       NOTIFY_SECRET: pay-notify-secret-needs-to-be-32-chars-fsghdngfhmhfkrgsfs
       NOTIFY_API_KEY: api_key-pay-notify-service-id-pay-notify-secret-needs-to-be-32-chars-fsghdngfhmhfkrgsfs
@@ -34,35 +47,28 @@ applications:
       NOTIFY_MANDATE_CANCELLED_EMAIL_TEMPLATE_ID: email-template-id
       SELFSERVICE_URL: https://pay-selfservice-((space)).london.cloudapps.digital
       FORGOTTEN_PASSWORD_EXPIRY_MINUTES: '90'
-      RUN_MIGRATION: 'true'
-      RUN_APP: 'true'
-      DISABLE_INTERNAL_HTTPS: 'true'
-      JAVA_OPTS: -Xms512m -Xmx1G
     routes:
     - route: pay-adminusers-((space)).london.cloudapps.digital
     - route: adminusers-((space)).apps.internal
-  - name: cardid
+  - <<: *applicationTemplate
+    name: cardid
     docker:
+      <<: *dockerImage
       image: govukpay/cardid:latest-master
-      username: ((docker-username))
-    health-check-type: process
-    memory: 1.5G
     env:
+      <<: *defaultEnvs
       ADMIN_PORT: '9801'
-      RUN_APP: 'true'
-      DISABLE_INTERNAL_HTTPS: 'true'
-      JAVA_OPTS: -Xms512m -Xmx1G
       AWS_XRAY_CONTEXT_MISSING: LOG_ERROR
     routes:
     - route: pay-cardid-((space)).london.cloudapps.digital
     - route: cardid-((space)).apps.internal
-  - name: card-connector
+  - <<: *applicationTemplate
+    name: card-connector
     docker:
+      <<: *dockerImage
       image: govukpay/connector:latest-master
-      username: ((docker-username))
-    health-check-type: process
-    memory: 1.5G
     env:
+      <<: *defaultEnvs
       ADMIN_PORT: '9301'
       DB_HOST: postgres-((space)).apps.internal
       DB_SSL_OPTION: ssl=none
@@ -111,19 +117,16 @@ applications:
       EVENT_QUEUE_ENABLED: 'true'
       AWS_SQS_PAYMENT_EVENT_QUEUE_URL: http://sqs-((space)).apps.internal:9324/queue/pay_event_queue
       RUN_MIGRATION: 'true'
-      RUN_APP: 'true'
-      DISABLE_INTERNAL_HTTPS: 'true'
-      JAVA_OPTS: -Xms512m -Xmx1G
     routes:
     - route: pay-card-connector-((space)).london.cloudapps.digital
     - route: card-connector-((space)).apps.internal
-  - name: directdebit-connector
+  - <<: *applicationTemplate
+    name: directdebit-connector
     docker:
+      <<: *dockerImage
       image: govukpay/directdebit-connector:latest-master
-      username: ((docker-username))
-    health-check-type: process
-    memory: 1.5G
     env:
+      <<: *defaultEnvs
       ENVIRONMENT: ((space))
       ADMIN_PORT: '10201'
       DB_HOST: postgres-((space)).apps.internal
@@ -147,21 +150,17 @@ applications:
       GOCARDLESS_LIVE_CLIENT_SECRET: gocardless-live-oauth-client-secret
       GOCARDLESS_TEST_OAUTH_BASE_URL: https://connect-sandbox.gocardless.com
       GOCARDLESS_LIVE_OAUTH_BASE_URL: https://connect-sandbox.gocardless.com
-      RUN_MIGRATION: 'true'
-      RUN_APP: 'true'
-      DISABLE_INTERNAL_HTTPS: 'true'
-      JAVA_OPTS: -Xms512m -Xmx1G
       AWS_XRAY_CONTEXT_MISSING: LOG_ERROR
       SENTRY_DSN: noop://localhost
     routes:
     - route: pay-directdebit-connector-((space)).london.cloudapps.digital
-  - name: directdebit-frontend
+  - <<: *applicationTemplate
+    name: directdebit-frontend
     docker:
+      <<: *dockerImage
       image: govukpay/directdebit-frontend:latest-master
-      username: ((docker-username))
-    health-check-type: process
-    memory: 1.5G
     env:
+      <<: *defaultEnvs
       NODE_WORKER_COUNT: '1'
       COOKIE_MAX_AGE: '5400000'
       SESSION_ENCRYPTION_KEY: asdjhbwefbo23r23rbfik2roiwhefwbqw
@@ -169,23 +168,23 @@ applications:
       ADMINUSERS_URL: https://pay-adminusers-((space)).london.cloudapps.digital
     routes:
     - route: pay-directdebit-frontend-((space)).london.cloudapps.digital
-  - name: egress
+  - <<: *applicationTemplate
+    name: egress
     docker:
+      <<: *dockerImage
       image: govukpay/egress@sha256:8bf84bc285b5be78a12a1611cfb3521efbdb6c83bd813f902623b01c0e5ad932
-      username: ((docker-username))
-    health-check-type: process
-    memory: 1.5G
     env:
+      <<: *defaultEnvs
       SQUID_CONFIG: YWNsIFNTTF9wb3J0cyBwb3J0IDQ0MwphY2wgU2FmZV9wb3J0cyBwb3J0IDgwCmFjbCBTYWZlX3BvcnRzIHBvcnQgNDQzCmh0dHBfYWNjZXNzIGFsbG93IGFsbApodHRwX3BvcnQgODA4MApjYWNoZSBkZW55IGFsbAphY2Nlc3NfbG9nIG5vbmUKY2FjaGVfbG9nIC9kZXYvbnVsbApjYWNoZV9zdG9yZV9sb2cgbm9uZQpwaWRfZmlsZW5hbWUgbm9uZQo=
     routes:
     - route: egress-((space)).apps.internal
-  - name: card-frontend
+  - <<: *applicationTemplate
+    name: card-frontend
     docker:
+      <<: *dockerImage
       image: govukpay/frontend:latest-master
-      username: ((docker-username))
-    health-check-type: process
-    memory: 1.5G
     env:
+      <<: *defaultEnvs
       SESSION_ENCRYPTION_KEY: asdjhbwefbo23r23rbfik2roiwhefwbqw
       COOKIE_MAX_AGE: '5400000'
       CONNECTOR_TOKEN_URL: http://card-connector-((space)).apps.internal:8080/v1/frontend/tokens/{chargeTokenId}
@@ -198,13 +197,13 @@ applications:
       ADMINUSERS_URL: http://adminusers-((space)).apps.internal:8080
     routes:
     - route: pay-card-frontend-((space)).london.cloudapps.digital
-  - name: ledger
+  - <<: *applicationTemplate
+    name: ledger
     docker:
+      <<: *dockerImage
       image: govukpay/ledger:latest-master
-      username: ((docker-username))
-    health-check-type: process
-    memory: 1.5G
     env:
+      <<: *defaultEnvs
       ADMIN_PORT: '10701'
       DB_HOST: postgres-((space)).apps.internal
       DB_SSL_OPTION: ssl=false
@@ -218,20 +217,16 @@ applications:
       AWS_SQS_MESSAGE_MAXIMUM_WAIT_TIME_IN_SECONDS: '20'
       QUEUE_MESSAGE_RECEIVER_THREAD_DELAY_IN_MILLISECONDS: '1000'
       AWS_SQS_PAYMENT_EVENT_QUEUE_URL: http://sqs-((space)).apps.internal:9324/queue/pay_event_queue
-      RUN_MIGRATION: 'true'
-      RUN_APP: 'true'
-      DISABLE_INTERNAL_HTTPS: 'true'
-      JAVA_OPTS: -Xms512m -Xmx1G
       AWS_XRAY_CONTEXT_MISSING: LOG_ERROR
     routes:
     - route: pay-ledger-((space)).london.cloudapps.digital
-  - name: products
+  - <<: *applicationTemplate
+    name: products
     docker:
+      <<: *dockerImage
       image: govukpay/products:latest-master
-      username: ((docker-username))
-    health-check-type: process
-    memory: 1.5G
     env:
+      <<: *defaultEnvs
       ADMIN_PORT: '10001'
       DB_HOST: postgres-((space)).apps.internal
       DB_SSL_OPTION: ssl=false
@@ -247,20 +242,16 @@ applications:
       PRODUCTS_FRIENDLY_BASE_URI: https://pay-products-ui-((space)).london.cloudapps.digital/redirect
       HTTP_PROXY_HOST: postgres-((space)).apps.internal
       HTTP_PROXY_PORT: '8080'
-      RUN_MIGRATION: 'true'
-      RUN_APP: 'true'
-      DISABLE_INTERNAL_HTTPS: 'true'
-      JAVA_OPTS: -Xms512m -Xmx1G
       AWS_XRAY_CONTEXT_MISSING: LOG_ERROR
     routes:
     - route: pay-products-((space)).london.cloudapps.digital
-  - name: products-ui
+  - <<: *applicationTemplate
+    name: products-ui
     docker:
+      <<: *dockerImage
       image: govukpay/products-ui:latest-master
-      username: ((docker-username))
-    health-check-type: process
-    memory: 1.5G
     env:
+      <<: *defaultEnvs
       PUBLICAPI_URL: https://pay-publicapi-((space)).london.cloudapps.digital
       PAY_API_URL: https://pay-publicapi-((space)).london.cloudapps.digital
       SELFSERVICE_TRANSACTIONS_URL: https://pay-selfservice-((space)).london.cloudapps.digital/transactions
@@ -271,13 +262,13 @@ applications:
       COOKIE_MAX_AGE: '3600000'
     routes:
     - route: pay-products-ui-((space)).london.cloudapps.digital
-  - name: publicapi
+  - <<: *applicationTemplate
+    name: publicapi
     docker:
+      <<: *dockerImage
       image: govukpay/publicapi:latest-master
-      username: ((docker-username))
-    health-check-type: process
-    memory: 1.5G
     env:
+      <<: *defaultEnvs
       ADMIN_PORT: '9101'
       CONNECTOR_URL: https://pay-card-connector-((space)).london.cloudapps.digital
       CONNECTOR_DD_URL: https://pay-directdebit-connector-((space)).london.cloudapps.digital
@@ -285,20 +276,16 @@ applications:
       TOKEN_API_HMAC_SECRET: qwer9yuhgf
       PUBLICAPI_BASE: https://pay-publicapi-((space)).london.cloudapps.digital
       LEDGER_URL: https://pay-ledger-((space)).london.cloudapps.digital
-      RUN_MIGRATION: 'true'
-      RUN_APP: 'true'
-      DISABLE_INTERNAL_HTTPS: 'true'
-      JAVA_OPTS: -Xms512m -Xmx1G
       AWS_XRAY_CONTEXT_MISSING: LOG_ERROR
     routes:
     - route: pay-publicapi-((space)).london.cloudapps.digital
-  - name: publicauth
+  - <<: *applicationTemplate
+    name: publicauth
     docker:
+      <<: *dockerImage
       image: govukpay/publicauth:latest-master
-      username: ((docker-username))
-    health-check-type: process
-    memory: 1.5G
     env:
+      <<: *defaultEnvs
       ADMIN_PORT: '9601'
       DB_HOST: postgres-((space)).apps.internal
       DB_SSL_OPTION: ssl=false
@@ -306,20 +293,16 @@ applications:
       DB_PASSWORD: mysecretpassword
       TOKEN_DB_BCRYPT_SALT: $2a$10$IhaXo6LIBhKIWOiGpbtPOu
       TOKEN_API_HMAC_SECRET: qwer9yuhgf
-      RUN_MIGRATION: 'true'
-      RUN_APP: 'true'
-      DISABLE_INTERNAL_HTTPS: 'true'
-      JAVA_OPTS: -Xms512m -Xmx1G
       AWS_XRAY_CONTEXT_MISSING: LOG_ERROR
     routes:
     - route: pay-publicauth-((space)).london.cloudapps.digital
-  - name: selfservice
+  - <<: *applicationTemplate
+    name: selfservice
     docker:
+      <<: *dockerImage
       image: govukpay/selfservice:latest-master
-      username: ((docker-username))
-    health-check-type: process
-    memory: 1.5G
     env:
+      <<: *defaultEnvs
       SESSION_ENCRYPTION_KEY: asdjhbwefbo23r23rbfik2roiwhefwbqw
       PUBLIC_AUTH_URL: https://pay-publicauth-((space)).london.cloudapps.digital/v1/frontend/auth
       CONNECTOR_URL: https://pay-card-connector-((space)).london.cloudapps.digital
@@ -342,19 +325,14 @@ applications:
       GOCARDLESS_TEST_OAUTH_BASE_URL: https://connect-sandbox.gocardless.com
       GOCARDLESS_LIVE_OAUTH_BASE_URL: https://connect-sandbox.gocardless.com
       SELFSERVICE_URL: https://pay-selfservice-((space)).london.cloudapps.digital
-      RUN_MIGRATION: 'true'
-      RUN_APP: 'true'
-      DISABLE_INTERNAL_HTTPS: 'true'
-      JAVA_OPTS: -Xms512m -Xmx1G
       AWS_XRAY_CONTEXT_MISSING: LOG_ERROR
     routes:
     - route: pay-selfservice-((space)).london.cloudapps.digital
-  - name: postgres
+  - <<: *applicationTemplate
+    name: postgres
     docker:
+      <<: *dockerImage
       image: postgres:latest
-      username: ((docker-username))
-    health-check-type: process
-    memory: 1.5G
     command: |
       echo "CREATE EXTENSION \"uuid-ossp\";
             CREATE EXTENSION IF NOT EXISTS pg_trgm WITH SCHEMA pg_catalog;
@@ -378,18 +356,19 @@ applications:
             GRANT ALL PRIVILEGES ON DATABASE ledger TO ledger;" > /docker-entrypoint-initdb.d/init.sql && \
       exec docker-entrypoint.sh postgres
     env:
+      <<: *defaultEnvs
       POSTGRES_PASSWORD: mysecretpassword
     routes:
     - route: postgres-((space)).apps.internal
-  - name: sqs
+  - <<: *applicationTemplate
+    name: sqs
     docker:
+      <<: *dockerImage
       image: roribio16/alpine-sqs@sha256:2651d01db38cc9faa8184a4c87a93d95aa2aa3bb992b9e41ea6b4742dc8893bb
-      username: ((docker-username))
     command: mkdir /opt/custom && echo "$EMQ_CONFIG" | base64 -d > /opt/custom/elasticmq.conf
       && /usr/bin/supervisord -n -c /etc/supervisor/supervisord.conf
-    health-check-type: process
-    memory: 1.5G
     env:
+      <<: *defaultEnvs
       EMQ_CONFIG: bm9kZS1hZGRyZXNzIHsKICBwcm90b2NvbCA9IGh0dHAKICBob3N0ID0gIioiCiAgcG9ydCA9IDkzMjQKICBjb250ZXh0LXBhdGggPSAiIgp9CgpyZXN0LXNxcyB7CiAgZW5hYmxlZCA9IHRydWUKICBiaW5kLXBvcnQgPSA5MzI0CiAgYmluZC1ob3N0bmFtZSA9ICIwLjAuMC4wIgogIC8vIFBvc3NpYmxlIHZhbHVlczogcmVsYXhlZCwgc3RyaWN0CiAgc3FzLWxpbWl0cyA9IHN0cmljdAp9CgpxdWV1ZXMgewogIGRlZmF1bHQgewogICAgZGVmYXVsdFZpc2liaWxpdHlUaW1lb3V0ID0gMTAgc2Vjb25kcwogICAgZGVsYXkgPSA1IHNlY29uZHMKICAgIHJlY2VpdmVNZXNzYWdlV2FpdCA9IDAgc2Vjb25kcwogIH0KCiAgcGF5X2NhcHR1cmVfcXVldWUgewogICAgZGVmYXVsdFZpc2liaWxpdHlUaW1lb3V0ID0gMzYwMCBzZWNvbmRzCiAgICBkZWxheSA9IDAgc2Vjb25kcwogICAgcmVjZWl2ZU1lc3NhZ2VXYWl0ID0gNSBzZWNvbmRzCiAgfQoKICBwYXlfZXZlbnRfcXVldWUgewogICAgZGVmYXVsdFZpc2liaWxpdHlUaW1lb3V0ID0gMzYwMCBzZWNvbmRzCiAgICBkZWxheSA9IDAgc2Vjb25kcwogICAgcmVjZWl2ZU1lc3NhZ2VXYWl0ID0gNSBzZWNvbmRzCiAgfQp9Cgpha2thLmh0dHAuc2VydmVyLnBhcnNpbmcuaWxsZWdhbC1oZWFkZXItd2FybmluZ3MgPSBvZmYKYWtrYS5odHRwLnNlcnZlci5yZXF1ZXN0LXRpbWVvdXQgPSA0MCBzZWNvbmRzCg==
     routes:
     - route: sqs-((space)).apps.internal


### PR DESCRIPTION
Create a template application structure to merge and override as
necessary.

## Notes
Does this make things clearer with less duplication or just more complicated? The rationale is that there is a lot of commonality between the apps that we needn't repeat.

## Testing
I cleared my space
`cf apps | awk 'NR > 4 {print $1}' | xargs -I {} cf delete -f {}`
Then deployed all the apps from the manifest, all started and seems ok
```
name                    requested state   instances   memory   disk   urls
adminusers              started           1/1         1.5G     1G     pay-adminusers-dev-dan.london.cloudapps.digital, adminusers-dev-dan.apps.internal
cardid                  started           1/1         1.5G     1G     pay-cardid-dev-dan.london.cloudapps.digital, cardid-dev-dan.apps.internal
card-connector          started           1/1         1.5G     1G     pay-card-connector-dev-dan.london.cloudapps.digital, card-connector-dev-dan.apps.internal
directdebit-connector   started           1/1         1.5G     1G     pay-directdebit-connector-dev-dan.london.cloudapps.digital
directdebit-frontend    started           1/1         1.5G     1G     pay-directdebit-frontend-dev-dan.london.cloudapps.digital
egress                  started           1/1         1.5G     1G     egress-dev-dan.apps.internal
card-frontend           started           1/1         1.5G     1G     pay-card-frontend-dev-dan.london.cloudapps.digital
ledger                  started           1/1         1.5G     1G     pay-ledger-dev-dan.london.cloudapps.digital
products                started           1/1         1.5G     1G     pay-products-dev-dan.london.cloudapps.digital
publicauth              started           1/1         1.5G     1G     pay-publicauth-dev-dan.london.cloudapps.digital
products-ui             started           1/1         1.5G     1G     pay-products-ui-dev-dan.london.cloudapps.digital
publicapi               started           1/1         1.5G     1G     pay-publicapi-dev-dan.london.cloudapps.digital
selfservice             started           1/1         1.5G     1G     pay-selfservice-dev-dan.london.cloudapps.digital
postgres                started           1/1         1.5G     1G     postgres-dev-dan.apps.internal
sqs                     started           1/1         1.5G     1G     sqs-dev-dan.apps.internal

```