### PR TITLE
Single task to apply network policies

### DIFF
--- a/ci/pipelines/deploy-env.yml
+++ b/ci/pipelines/deploy-env.yml
@@ -101,6 +101,7 @@ resources:
 
 jobs:
   - name: provision-space
+    serial: true
     plan:
       - get: omnibus
         trigger: true
@@ -193,135 +194,12 @@ jobs:
           params:
             <<: *create-app-params
             APP: sqs
-      - in_parallel:
-        - put: network-policy-adminusers-egress
-          resource: paas
-          params:
-            command: add-network-policy
-            source_app: adminusers
-            destination_app: egress
-            port: 8080
-            protocol: tcp
-        - put: network-policy-adminusers-postgres
-          resource: paas
-          params:
-            command: add-network-policy
-            source_app: adminusers
-            destination_app: postgres
-            port: 5432
-            protocol: tcp
-        - put: network-policy-card-frontend-card-connector
-          resource: paas
-          params:
-            command: add-network-policy
-            source_app: card-frontend
-            destination_app: card-connector
-            port: 8080
-            protocol: tcp
-        - put: network-policy-card-frontend-cardid
-          resource: paas
-          params:
-            command: add-network-policy
-            source_app: card-frontend
-            destination_app: cardid
-            port: 8080
-            protocol: tcp
-        - put: network-policy-card-frontend-adminusers
-          resource: paas
-          params:
-            command: add-network-policy
-            source_app: card-frontend
-            destination_app: adminusers
-            port: 8080
-            protocol: tcp
-        - put: network-policy-card-connector-egress
-          resource: paas
-          params:
-            command: add-network-policy
-            source_app: card-connector
-            destination_app: egress
-            port: 8080
-            protocol: tcp
-        - put: network-policy-card-connector-postgres
-          resource: paas
-          params:
-            command: add-network-policy
-            source_app: card-connector
-            destination_app: postgres
-            port: 5432
-            protocol: tcp
-        - put: network-policy-card-connector-sqs
-          resource: paas
-          params:
-            command: add-network-policy
-            source_app: card-connector
-            destination_app: sqs
-            port: 9324
-            protocol: tcp
-        - put: network-policy-directdebit-frontend-directdebit-connector
-          resource: paas
-          params:
-            command: add-network-policy
-            source_app: directdebit-frontend
-            destination_app: directdebit-connector
-            port: 8080
-            protocol: tcp
-        - put: network-policy-directdebit-frontend-egress
-          resource: paas
-          params:
-            command: add-network-policy
-            source_app: directdebit-frontend
-            destination_app: adminusers
-            port: 8080
-            protocol: tcp
-        - put: network-policy-directdebit-connector-egress
-          resource: paas
-          params:
-            command: add-network-policy
-            source_app: directdebit-connector
-            destination_app: egress
-            port: 8080
-            protocol: tcp
-        - put: network-policy-directdebit-connector-postgres
-          resource: paas
-          params:
-            command: add-network-policy
-            source_app: directdebit-connector
-            destination_app: postgres
-            port: 5432
-            protocol: tcp
-        - put: network-policy-publicauth-postgres
-          resource: paas
-          params:
-            command: add-network-policy
-            source_app: publicauth
-            destination_app: postgres
-            port: 5432
-            protocol: tcp
-        - put: network-policy-products-postgres
-          resource: paas
-          params:
-            command: add-network-policy
-            source_app: products
-            destination_app: postgres
-            port: 5432
-            protocol: tcp
-        - put: network-policy-ledger-postgres
-          resource: paas
-          params:
-            command: add-network-policy
-            source_app: ledger
-            destination_app: postgres
-            port: 5432
-            protocol: tcp
-        - put: network-policy-ledger-sqs
-          resource: paas
-          params:
-            command: add-network-policy
-            source_app: ledger
-            destination_app: sqs
-            port: 9324
-            protocol: tcp
+      - task: apply-network-policies
+        file: omnibus/ci/tasks/apply-network-policies.yml
+        params: &create-app-params
+          CF_ORG: govuk-pay
+          CF_SPACE: ((space))
+          POLICIES_FILE: omnibus/paas/network-policies.yml
 
   - name: delete-space
     plan:

--- a/ci/tasks/apply-network-policies.yml
+++ b/ci/tasks/apply-network-policies.yml
@@ -1,0 +1,26 @@
+platform: linux
+
+image_resource:
+  type: docker-image
+  source: { repository: governmentpaas/cf-cli }
+
+params:
+  CF_USERNAME: ((cf-username))
+  CF_PASSWORD: ((cf-password))
+  CF_ORG:
+  CF_SPACE:
+  POLICIES_FILE:
+
+inputs:
+  - name: omnibus
+
+run:
+  path: bash
+  args:
+    - -c
+    - |
+      set -o errexit -o nounset
+      cf login -a https://api.london.cloud.service.gov.uk \
+        -u "$CF_USERNAME" -p "$CF_PASSWORD" \
+        -o "$CF_ORG" -s "$CF_SPACE"
+      ruby omnibus/paas/apply_network_policies.rb "$POLICIES_FILE"

--- a/paas/apply_network_policies.rb
+++ b/paas/apply_network_policies.rb
@@ -1,0 +1,16 @@
+#!/usr/bin/env ruby
+
+require 'yaml'
+
+abort "Usage: #{__FILE__} network-policies.yml" if ARGV.size < 1
+
+YAML.load_file(ARGV[0]).fetch('network-policies').each do |policy|
+  source_app = policy.fetch('src')
+  dest_app = policy.fetch('dest')
+  port_range = policy.fetch('ports')
+  protocol = policy.fetch('protocol', 'tcp')
+  dest_space = policy.key?('dest-space') ? "-s #{policy['dest-space']}" : ""
+
+  `cf add-network-policy #{source_app} --destination-app #{dest_app} #{dest_space} --protocol #{protocol} --port #{port_range}`
+  puts "Added network policy: source=#{source_app} destination=#{dest_app} dest_space=#{dest_space} protocol=#{protocol} port=#{port_range}" if $? == 0
+end

--- a/paas/network-policies.yml
+++ b/paas/network-policies.yml
@@ -1,48 +1,73 @@
+---
 network-policies:
   - src: adminusers
     dest: egress
-    ports: 8080-8080
-  - src: card-connector
-    dest: egress
-    ports: 8080-8080
-  - src: directdebit-connector
-    dest: egress
-    ports: 8080-8080
-  - src: card-frontend
-    dest: card-connector
-    ports: 8080-8080
-  - src: card-frontend
-    dest: card-connector
-    ports: 8080-8080
-  - src: card-frontend
-    dest: cardid
-    ports: 8080-8080
-  - src: card-frontend
-    dest: adminusers
-    ports: 8080-8080
-
+    ports: 8080
+    protocol: tcp
   - src: adminusers
     dest: postgres
-    ports: 5432-5432
-  - src: card-connector
-    dest: postgres
-    ports: 5432-5432
-  - src: publicauth
-    dest: postgres
-    ports: 5432-5432
-  - src: directdebit-connector
-    dest: postgres
-    ports: 5432-5432
-  - src: products
-    dest: postgres
-    ports: 5432-5432
-  - src: ledger
-    dest: postgres
-    ports: 5432-5432
+    ports: 5432
+    protocol: tcp
+
+  - src: card-frontend
+    dest: card-connector
+    ports: 8080
+    protocol: tcp
+  - src: card-frontend
+    dest: cardid
+    ports: 8080
+    protocol: tcp
+  - src: card-frontend
+    dest: adminusers
+    ports: 8080
+    protocol: tcp
 
   - src: card-connector
+    dest: egress
+    ports: 8080
+    protocol: tcp
+  - src: card-connector
+    dest: postgres
+    ports: 5432
+    protocol: tcp
+  - src: card-connector
     dest: sqs
-    ports: 9324-9324
+    ports: 9324
+    protocol: tcp
+
+  - src: directdebit-frontend
+    dest: directdebit-connector
+    ports: 8080
+    protocol: tcp
+  - src: directdebit-frontend
+    dest: adminusers
+    ports: 8080
+    protocol: tcp
+
+  - src: directdebit-connector
+    dest: egress
+    ports: 8080
+    protocol: tcp
+  - src: directdebit-connector
+    dest: postgres
+    ports: 5432
+    protocol: tcp
+
+  - src: ledger
+    dest: postgres
+    ports: 5432
+    protocol: tcp
   - src: ledger
     dest: sqs
-    ports: 9324-9324
+    ports: 9324
+    protocol: tcp
+
+  - src: publicauth
+    dest: postgres
+    ports: 5432
+    protocol: tcp
+
+  - src: products
+    dest: postgres
+    ports: 5432
+    protocol: tcp


### PR DESCRIPTION
We were running into issues with too many containers on our Concourse
workers. We probably don't need to have a separate `put` for each and
every network policy. Instead, we can use `paas/network-policies.yml` as
the canonical source for network policies and apply them all in one go.

Something to think about is that this won't remove already existing
policies but that could be added later. Also I'm not using Andy's cf-cli
plugin because it needs Go to install.