### PR TITLE
Notification endpoint smoke tests

### DIFF
--- a/ci/pipelines/smoke-tests.yml
+++ b/ci/pipelines/smoke-tests.yml
@@ -12,6 +12,8 @@ groups:
       - card-smoke-test
       - directdebit-smoke-test
       - products-smoke-test
+      - notifications-card-smoke-test
+      - notifications-directdebit-smoke-test
 
 resource_types:
   - name: cf-cli
@@ -150,3 +152,29 @@ jobs:
           CF_ORG: govuk-pay
           CF_SPACE: tools
           COMMAND: cf ssh endtoend -c /app/bin/smoke-products
+
+  - name: notifications-card-smoke-test
+    serial: true
+    plan:
+      - get: every-10m
+        trigger: true
+      - get: omnibus
+      - task: run notifications card smoke test
+        file: omnibus/ci/tasks/run-notifications-smoke-test.yml
+        params:
+          CF_ORG: govuk-pay
+          CF_SPACE: tools
+          NOTIFICATIONS_URL: ((notifications_smoke_card_url))
+
+  - name: notifications-directdebit-smoke-test
+    serial: true
+    plan:
+      - get: every-10m
+        trigger: true
+      - get: omnibus
+      - task: run notifications direct debit smoke test
+        file: omnibus/ci/tasks/run-notifications-smoke-test.yml
+        params:
+          CF_ORG: govuk-pay
+          CF_SPACE: tools
+          NOTIFICATIONS_URL: ((notifications_smoke_dd_url))

--- a/ci/tasks/run-notifications-smoke-test.yml
+++ b/ci/tasks/run-notifications-smoke-test.yml
@@ -1,0 +1,29 @@
+platform: linux
+
+image_resource:
+  type: docker-image
+  source: { repository: governmentpaas/cf-cli }
+
+params:
+  CF_USERNAME: ((cf-username))
+  CF_PASSWORD: ((cf-password))
+  CF_ORG:
+  CF_SPACE:
+  NOTIFICATIONS_URL:
+
+run:
+  path: bash
+  args:
+    - -c
+    - |
+      set -o nounset
+      cf login -a https://api.london.cloud.service.gov.uk \
+        -u "$CF_USERNAME" -p "$CF_PASSWORD" \
+        -o "$CF_ORG" -s "$CF_SPACE"
+
+      httpcode=$(cf ssh endtoend -c "curl -s --write-out '%{http_code}\n' --fail -X POST -H 'Content-Type: application/json' -d '{"content_for" : "naxsi_rules"}' "${NOTIFICATIONS_URL}"")
+
+      if [ "$httpcode" != 200 ]; then
+        echo "$0: $NOTIFICATIONS_URL responded with status code '$httpcode'"
+        exit 1
+      fi


### PR DESCRIPTION
Adds smoke tests used to check availability of card and dd notifications endpoints.
Works by running remote curl command from app hosted on PaaS.

Based on existing script: https://github.com/alphagov/pay-chef/blob/master/cookbooks/pay-ci/templates/default/jenkins_jobs/scheduled-notifications-smoke-run.groovy.erb