### PR TITLE
Fix dd notifications smoke test

### DIFF
--- a/ci/pipelines/smoke-tests.yml
+++ b/ci/pipelines/smoke-tests.yml
@@ -153,6 +153,20 @@ jobs:
           CF_SPACE: tools
           COMMAND: cf ssh endtoend -c /app/bin/smoke-products
 
+  - name: notifications-directdebit-smoke-test
+    serial: true
+    plan:
+      - get: every-10m
+        trigger: true
+      - get: omnibus
+      - task: run direct debit notifications smoke test
+        file: omnibus/ci/tasks/cf-task.yml
+        params:
+          CF_ORG: govuk-pay
+          CF_SPACE: tools
+          COMMAND: cf ssh endtoend -c /app/bin/smoke-directdebit-notifications
+
+  # Card notification smoke tests are executed using curl
   - name: notifications-card-smoke-test
     serial: true
     plan:
@@ -165,16 +179,3 @@ jobs:
           CF_ORG: govuk-pay
           CF_SPACE: tools
           NOTIFICATIONS_URL: ((notifications_smoke_card_url))
-
-  - name: notifications-directdebit-smoke-test
-    serial: true
-    plan:
-      - get: every-10m
-        trigger: true
-      - get: omnibus
-      - task: run notifications direct debit smoke test
-        file: omnibus/ci/tasks/run-notifications-smoke-test.yml
-        params:
-          CF_ORG: govuk-pay
-          CF_SPACE: tools
-          NOTIFICATIONS_URL: ((notifications_smoke_dd_url))

--- a/ci/tasks/run-notifications-smoke-test.yml
+++ b/ci/tasks/run-notifications-smoke-test.yml
@@ -22,8 +22,8 @@ run:
         -o "$CF_ORG" -s "$CF_SPACE"
 
       httpcode=$(cf ssh endtoend -c "curl -s --write-out '%{http_code}\n' --fail -X POST -H 'Content-Type: application/json' -d '{"content_for" : "naxsi_rules"}' "${NOTIFICATIONS_URL}"")
+      echo "$0: $NOTIFICATIONS_URL responded with status code '$httpcode'"
 
       if [ "$httpcode" != 200 ]; then
-        echo "$0: $NOTIFICATIONS_URL responded with status code '$httpcode'"
         exit 1
       fi


### PR DESCRIPTION
DD notifications smoke tests still run via the e2e java app (see: https://github.com/alphagov/pay-endtoend/blob/master/bin/smoke-directdebit-notifications)
This PR executes these via the remote endtoend app.

Card notifications smoke tests just use a Curl request to test the endpoint, see: https://github.com/alphagov/pay-chef/blob/master/cookbooks/pay-ci/templates/default/jenkins_jobs/scheduled-notifications-smoke-run.groovy.erb