### PR TITLE
PP-5876: add notifications service to paas skeleton

### DIFF
--- a/ci/pipelines/deploy-env.yml
+++ b/ci/pipelines/deploy-env.yml
@@ -103,7 +103,7 @@ resources:
     name: notifications
     source:
       <<: *image-source
-      repository: govukpay/notifications
+      repository: govukpaypaas/notifications
 
 jobs:
   - name: provision-space
@@ -393,7 +393,7 @@ jobs:
           <<: *paas-app
           app_name: selfservice
 
-  - name: deploy-notifications
+  - name: deploy-notificationss
     serial_groups: [notifications]
     plan:
       - get: omnibus

--- a/ci/pipelines/deploy-env.yml
+++ b/ci/pipelines/deploy-env.yml
@@ -393,7 +393,7 @@ jobs:
           <<: *paas-app
           app_name: selfservice
 
-  - name: deploy-notificationss
+  - name: deploy-notifications
     serial_groups: [notifications]
     plan:
       - get: omnibus

--- a/ci/pipelines/deploy-env.yml
+++ b/ci/pipelines/deploy-env.yml
@@ -101,9 +101,9 @@ resources:
 
   - <<: *image
     name: notifications
-      source:
-        <<: *image-source
-        repository: govukpay/notifications
+    source:
+      <<: *image-source
+      repository: govukpay/notifications
 
 jobs:
   - name: provision-space
@@ -186,6 +186,11 @@ jobs:
             <<: *create-app-params
             APP: selfservice
         - <<: *create-app
+          task: create-notifications
+          params:
+            <<: *create-app-params
+            APP: notifications
+        - <<: *create-app
           task: create-egress
           params:
             <<: *create-app-params
@@ -200,9 +205,6 @@ jobs:
           params:
             <<: *create-app-params
             APP: sqs
-        - <<: *create-app
-          task: create-notifications
-            APP: notifications
       - task: apply-network-policies
         file: omnibus/ci/tasks/apply-network-policies.yml
         params: &create-app-params
@@ -391,6 +393,20 @@ jobs:
           <<: *paas-app
           app_name: selfservice
 
+  - name: deploy-notifications
+    serial_groups: [notifications]
+    plan:
+      - get: omnibus
+        passed: [provision-space, deploy-tools]
+        trigger: true
+      - get: notifications
+        trigger: true
+      - put: app
+        resource: paas
+        params:
+          <<: *paas-app
+          app_name: notifications
+
   - name: deploy-tools
     serial_groups: [tools]
     plan:
@@ -412,16 +428,5 @@ jobs:
         params:
           <<: *paas-app
           app_name: postgres
-  - name: deploy-notifications
-    serial_groups: [notifications]
-    plan:
-      - get: omnibus
-        passed: [provision-space, deploy-tools]
-        trigger: true
-      - get: notifications
-        trigger: true
-      - put: app
-        resource: paas
-        params:
-          <<: *paas-app
-          app_name: notifications
+
+  

--- a/ci/pipelines/deploy-env.yml
+++ b/ci/pipelines/deploy-env.yml
@@ -11,7 +11,7 @@ resources:
     icon: github-circle
     source:
       uri: https://github.com/alphagov/pay-omnibus
-      branch: PP-5876-Add-notifications-to-skeleton
+      branch: develop
 
   - name: paas
     type: cf-cli
@@ -428,5 +428,3 @@ jobs:
         params:
           <<: *paas-app
           app_name: postgres
-
-  

--- a/ci/pipelines/deploy-env.yml
+++ b/ci/pipelines/deploy-env.yml
@@ -11,7 +11,7 @@ resources:
     icon: github-circle
     source:
       uri: https://github.com/alphagov/pay-omnibus
-      branch: develop
+      branch: PP-5876-Add-notifications-to-skeleton
 
   - name: paas
     type: cf-cli
@@ -98,6 +98,12 @@ resources:
     source:
       <<: *image-source
       repository: govukpay/selfservice
+
+  - <<: *image
+    name: notifications
+      source:
+        <<: *image-source
+        repository: govukpay/notifications
 
 jobs:
   - name: provision-space
@@ -194,6 +200,9 @@ jobs:
           params:
             <<: *create-app-params
             APP: sqs
+        - <<: *create-app
+          task: create-notifications
+            APP: notifications
       - task: apply-network-policies
         file: omnibus/ci/tasks/apply-network-policies.yml
         params: &create-app-params
@@ -403,3 +412,16 @@ jobs:
         params:
           <<: *paas-app
           app_name: postgres
+  - name: deploy-notifications
+    serial_groups: [notifications]
+    plan:
+      - get: omnibus
+        passed: [provision-space, deploy-tools]
+        trigger: true
+      - get: notifications
+        trigger: true
+      - put: app
+        resource: paas
+        params:
+          <<: *paas-app
+          app_name: notifications

--- a/paas/network-policies.yml
+++ b/paas/network-policies.yml
@@ -74,9 +74,9 @@ network-policies:
 
   - src: notifications
     dest: directdebit-connector
-    ports: 443
+    ports: 8080
     protocol: tcp
   - src: notifications
     dest: card-connector
-    ports: 443
+    ports: 8080
     protocol: tcp

--- a/paas/network-policies.yml
+++ b/paas/network-policies.yml
@@ -71,3 +71,12 @@ network-policies:
     dest: postgres
     ports: 5432
     protocol: tcp
+
+  - src: notifications
+    dest: directdebit-connector
+    ports: 443
+    protocol: tcp
+  - src: notifications
+    dest: card-connector
+    ports: 443
+    protocol: tcp

--- a/paas/pay-apps.yml
+++ b/paas/pay-apps.yml
@@ -329,8 +329,8 @@ applications:
       <<: *dockerImage
       image: govukpaypaas/notifications:latest-master
     env:
-      CONNECTOR_URL: https://card-connector-((space)).apps.internal
-      DD_CONNECTOR_URL: https://directdebit-connector-((space)).apps.internal
+      CONNECTOR_URL: http://card-connector-((space)).apps.internal:8080
+      DD_CONNECTOR_URL: http://directdebit-connector-((space)).apps.internal:8080
       TINI_SUBREAPER: ''
     routes:
     - route: pay-notifications-((space)).london.cloudapps.digital

--- a/paas/pay-apps.yml
+++ b/paas/pay-apps.yml
@@ -331,6 +331,7 @@ applications:
     env:
       CONNECTOR_URL: https://card-connector-((space)).apps.internal
       DD_CONNECTOR_URL: https://directdebit-connector-((space)).apps.internal
+      TINI_SUBREAPER: ''
   - <<: *applicationTemplate
     name: postgres
     docker:

--- a/paas/pay-apps.yml
+++ b/paas/pay-apps.yml
@@ -151,6 +151,7 @@ applications:
       SENTRY_DSN: noop://localhost
     routes:
     - route: pay-directdebit-connector-((space)).london.cloudapps.digital
+    - route: directdebit-connector-((space)).apps.internal
   - <<: *applicationTemplate
     name: directdebit-frontend
     docker:

--- a/paas/pay-apps.yml
+++ b/paas/pay-apps.yml
@@ -332,6 +332,8 @@ applications:
       CONNECTOR_URL: https://card-connector-((space)).apps.internal
       DD_CONNECTOR_URL: https://directdebit-connector-((space)).apps.internal
       TINI_SUBREAPER: ''
+    routes:
+    - route: pay-notifications-((space)).london.cloudapps.digital
   - <<: *applicationTemplate
     name: postgres
     docker:

--- a/paas/pay-apps.yml
+++ b/paas/pay-apps.yml
@@ -323,6 +323,14 @@ applications:
     routes:
     - route: pay-selfservice-((space)).london.cloudapps.digital
   - <<: *applicationTemplate
+    name: notifications
+    docker:
+      <<: *dockerImage
+      image: govukpay/notifications:latest-master
+    env:
+      CONNECTOR_URL: https://card-connector-((space)).apps.internal
+      DD_CONNECTOR_URL: https://directdebit-connector-((space)).apps.internal
+  - <<: *applicationTemplate
     name: postgres
     docker:
       <<: *dockerImage

--- a/paas/pay-apps.yml
+++ b/paas/pay-apps.yml
@@ -327,7 +327,7 @@ applications:
     name: notifications
     docker:
       <<: *dockerImage
-      image: govukpay/notifications:latest-master
+      image: govukpaypaas/notifications:latest-master
     env:
       CONNECTOR_URL: https://card-connector-((space)).apps.internal
       DD_CONNECTOR_URL: https://directdebit-connector-((space)).apps.internal


### PR DESCRIPTION
Adds the notifications/naxsi service in front of connector & dd-connector.
The notifications container required some modifications to run on PaaS. 

Specifically:
* Disable default nginx ipv6 listener as this isn't supported and causes the container to crash
* Bind nginx DNS resolver to PaaS DNS host. This is now configurable.
* Removed self-signed SSL cert config. This isn't needed as envoy should handle this implicitly.
* Configure Tini (init script) to run as a subreaper since CF already has an init system.

Notifications container changes are on the following branch: https://github.com/alphagov/pay-notifications/tree/paas_configuration

Paired with @nimalank7 