### PR TITLE
PP-5836: Escape double quotes in card notification smoke test

### DIFF
--- a/ci/tasks/run-notifications-smoke-test.yml
+++ b/ci/tasks/run-notifications-smoke-test.yml
@@ -21,7 +21,7 @@ run:
         -u "$CF_USERNAME" -p "$CF_PASSWORD" \
         -o "$CF_ORG" -s "$CF_SPACE"
 
-      httpcode=$(cf ssh endtoend -c "curl -s --write-out '%{http_code}\n' --fail -X POST -H 'Content-Type: application/json' -d '{"content_for" : "naxsi_rules"}' "${NOTIFICATIONS_URL}"")
+      httpcode=$(cf ssh endtoend -c "curl -s --write-out '%{http_code}\n' --fail -X POST -H 'Content-Type: application/json' -d '{\"content_for\" : \"naxsi_rules\"}' "${NOTIFICATIONS_URL}"")
       echo "$0: $NOTIFICATIONS_URL responded with status code '$httpcode'"
 
       if [ "$httpcode" != 200 ]; then


### PR DESCRIPTION
When executed remotely, unescaped double quotes cause payload to become malformed.