### PR TITLE
PP-5836: Update dd notification smoke url to use notification service

### DIFF
--- a/paas/smoke-test-apps.yml
+++ b/paas/smoke-test-apps.yml
@@ -29,5 +29,5 @@ applications:
       SELFSERVICE_PASSWORD: something
       SELFSERVICE_OTP_KEY: something
       SELFSERVICE_URL: something
-      NOTIFICATIONS_URL: https://pay-directdebit-connector-staging.london.cloudapps.digital
+      NOTIFICATIONS_URL: https://pay-notifications-staging.london.cloudapps.digital
       DIRECT_DEBIT_GOCARDLESS_WEBHOOK_SECRET: supersecret


### PR DESCRIPTION
The notification service is now running. Point dd notification smoke tests at it.