### PR TITLE
Move smoke test env var definitions to separate file

### DIFF
--- a/ci/pipelines/smoke-tests.yml
+++ b/ci/pipelines/smoke-tests.yml
@@ -73,7 +73,8 @@ jobs:
             docker_password: ((docker-password))
             docker_username: ((docker-username))
             docker_image: govukpay/endtoend:latest-master
-       
+          vars_files:
+            - omnibus/paas/env_variables/staging-smoke-tests.yml
         - put: network-policy-endtoend-selenium-hub
           resource: paas-tools
           params:

--- a/paas/env_variables/staging-smoke-tests.yml
+++ b/paas/env_variables/staging-smoke-tests.yml
@@ -1,0 +1,10 @@
+---
+selenium_hub_url: http://selenium-hub.apps.internal:4444/wd/hub
+publicapi_url: https://pay-publicapi-staging.london.cloudapps.digital
+card_sandbox_api_token: someapitoken
+smoke_test_product_payment_link_url: https://pay-products-staging.london.cloudapps.digital/redirect/smoke-test/product-test-environment
+selfservice_password: something
+selfservice_otp_key: something
+selfservice_url: something
+notifications_url: https://pay-notifications-staging.london.cloudapps.digital
+direct_debit_gocardless_webhook_secret: supersecret

--- a/paas/smoke-test-apps.yml
+++ b/paas/smoke-test-apps.yml
@@ -21,13 +21,13 @@ applications:
     instances: 1
     env:
       WEB_DRIVER: CHROME_REMOTE
-      SELENIUM_HUB_URL: http://selenium-hub.apps.internal:4444/wd/hub
       CHROME_DRIVER_PATH: /usr/bin/chromedriver
-      PUBLICAPI_URL: https://pay-publicapi-staging.london.cloudapps.digital
-      CARD_SANDBOX_API_TOKEN: someapitoken
-      SMOKE_TEST_PRODUCT_PAYMENT_LINK_URL: https://pay-products-staging.london.cloudapps.digital/redirect/smoke-test/product-test-environment
-      SELFSERVICE_PASSWORD: something
-      SELFSERVICE_OTP_KEY: something
-      SELFSERVICE_URL: something
-      NOTIFICATIONS_URL: https://pay-notifications-staging.london.cloudapps.digital
-      DIRECT_DEBIT_GOCARDLESS_WEBHOOK_SECRET: supersecret
+      SELENIUM_HUB_URL: ((selenium_hub_url))
+      PUBLICAPI_URL: ((publicapi_url))
+      CARD_SANDBOX_API_TOKEN: ((card_sandbox_api_token))
+      SMOKE_TEST_PRODUCT_PAYMENT_LINK_URL: ((smoke_test_product_payment_link_url))
+      SELFSERVICE_PASSWORD: ((selfservice_password))
+      SELFSERVICE_OTP_KEY: ((selfservice_otp_key))
+      SELFSERVICE_URL: ((selfservice_url))
+      NOTIFICATIONS_URL: ((notifications_url))
+      DIRECT_DEBIT_GOCARDLESS_WEBHOOK_SECRET: ((direct_debit_gocardless_webhook_secret))


### PR DESCRIPTION
Moves smoke test environment variable value definitions to a separate file. This will make it easier to reuse the endtoend app definition for other environments.