### PR TITLE
PP-5836: Fix smoke tests

### DIFF
--- a/ci/pipelines/smoke-tests.yml
+++ b/ci/pipelines/smoke-tests.yml
@@ -127,7 +127,7 @@ jobs:
         params:
           CF_ORG: govuk-pay
           CF_SPACE: tools
-          COMMAND: cf ssh endtoend -c /app/bin/smoke-card
+          COMMAND: cf ssh endtoend -c /app/bin/smoke-cardp1
 
   - name: directdebit-smoke-test
     serial: true

--- a/ci/pipelines/smoke-tests.yml
+++ b/ci/pipelines/smoke-tests.yml
@@ -140,7 +140,7 @@ jobs:
         params:
           CF_ORG: govuk-pay
           CF_SPACE: tools
-          COMMAND: cf ssh endtoend -c /app/bin/smoke-directdebit
+          COMMAND: cf ssh endtoend -c /app/bin/smoke-directdebitp1
 
   - name: products-smoke-test
     serial: true

--- a/paas/env_variables/staging-smoke-tests.yml
+++ b/paas/env_variables/staging-smoke-tests.yml
@@ -1,7 +1,7 @@
 ---
 selenium_hub_url: http://selenium-hub.apps.internal:4444/wd/hub
 publicapi_url: https://pay-publicapi-staging.london.cloudapps.digital
-card_sandbox_api_token: stema5ug5agkr8fp3kjeu9a2vtthdsh9lir54et7jcbtrirflsp8pc15lh
+card_sandbox_api_token: 5d34s8as3d8pckclenmsugnucf0hq0mg967buv8nap0fla6il2nuhgagfp
 smoke_test_product_payment_link_url: https://pay-products-staging.london.cloudapps.digital/redirect/smoke-test/product-test-environment
 selfservice_password: something
 selfservice_otp_key: something

--- a/paas/env_variables/staging-smoke-tests.yml
+++ b/paas/env_variables/staging-smoke-tests.yml
@@ -2,6 +2,7 @@
 selenium_hub_url: http://selenium-hub.apps.internal:4444/wd/hub
 publicapi_url: https://pay-publicapi-staging.london.cloudapps.digital
 card_sandbox_api_token: 5d34s8as3d8pckclenmsugnucf0hq0mg967buv8nap0fla6il2nuhgagfp
+directdebit_sandbox_api_token: a88nm9mgn81t3ioa8jd0fgfo2prf9vugev1qdga4fmkupceqo3k6mvgnf1
 smoke_test_product_payment_link_url: https://pay-products-staging.london.cloudapps.digital/redirect/smoke-test/product-test-environment
 selfservice_password: something
 selfservice_otp_key: something

--- a/paas/smoke-test-apps.yml
+++ b/paas/smoke-test-apps.yml
@@ -25,6 +25,7 @@ applications:
       SELENIUM_HUB_URL: ((selenium_hub_url))
       PUBLICAPI_URL: ((publicapi_url))
       CARD_SANDBOX_API_TOKEN: ((card_sandbox_api_token))
+      DIRECT_DEBIT_SANDBOX_API_TOKEN: ((direct_debit_sandbox_api_token))
       SMOKE_TEST_PRODUCT_PAYMENT_LINK_URL: ((smoke_test_product_payment_link_url))
       SELFSERVICE_PASSWORD: ((selfservice_password))
       SELFSERVICE_OTP_KEY: ((selfservice_otp_key))


### PR DESCRIPTION
Updates creds for card and dd sandbox users.
Runs p1 sandbox tests only.