### PR TITLE
PP-5847: Concourse pipeline for pay-tech-docs

### DIFF
--- a/ci/pipelines/pay-tech-docs.yml
+++ b/ci/pipelines/pay-tech-docs.yml
@@ -1,0 +1,61 @@
+---
+resource_types:
+  - name: cf-cli
+    type: docker-image
+    source:
+      repository: nulldriver/cf-cli-resource
+
+resources:
+  - name: pay-tech-docs
+    type: git
+    icon: github-circle
+    source:
+      uri: https://github.com/alphagov/pay-tech-docs
+      branch: master
+
+  - name: paas
+    type: cf-cli
+    icon: cloud-upload-outline
+    source:
+      api: https://api.cloud.service.gov.uk
+      org: govuk-pay
+      space: docs
+      username: ((paas-ireland-username))
+      password: ((paas-ireland-password))
+
+jobs:
+  - name: deploy
+    serial: true
+    plan:
+      - get: pay-tech-docs
+        trigger: true
+      - task: build
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: ruby
+          inputs:
+            - name: pay-tech-docs
+          outputs:
+            - name: pay-tech-docs/build
+          caches:
+            - path: pay-tech-docs/vendor
+          run:
+            dir: pay-tech-docs/docs
+            path: bash
+            args:
+              - -c
+              - |
+                set -o errexit -o nounset -o pipefail
+                apt-get update && apt-get install -y nodejs npm
+                gem install bundler
+                bundle install --deployment
+                bundle exec middleman build
+      - put: paas
+        params:
+          command: push
+          app_name: govuk-pay-tech-docs
+          path: pay-tech-docs/build
+          manifest: pay-tech-docs/manifest.yml


### PR DESCRIPTION
It looks like this worked at https://cd.gds-reliability.engineering/teams/pay-deploy/pipelines/pay-tech-docs/jobs/deploy/builds/1