### PR TITLE
PP-5894: Terraform for Cloudfront

### DIFF
--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,1 @@
+.terraform

--- a/terraform/environment/cloudfront.tf
+++ b/terraform/environment/cloudfront.tf
@@ -1,0 +1,58 @@
+resource "aws_s3_bucket" "cloudfront_logs" {
+  bucket = "govuk-pay-cloudfront-logs-${var.environment}"
+  acl    = "private"
+}
+
+resource "aws_cloudfront_distribution" "main" {
+  enabled = "true"
+  comment = "cloudfront-${var.environment}"
+
+  logging_config {
+    include_cookies = false
+    bucket          = aws_s3_bucket.cloudfront_logs.bucket_domain_name
+  }
+
+  aliases = ["*.staging.gdspay.uk"]
+
+  default_cache_behavior {
+    target_origin_id       = "paas_london"
+    viewer_protocol_policy = "redirect-to-https"
+    allowed_methods        = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods         = ["GET", "HEAD"]
+    min_ttl                = 0
+    max_ttl                = 0
+    default_ttl            = 0
+
+    forwarded_values {
+      headers      = ["Host", "Origin"]
+      query_string = true
+      cookies {
+        forward = "all"
+      }
+    }
+  }
+
+  origin {
+    origin_id   = "paas_london"
+    domain_name = "london.cloudapps.digital"
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = aws_acm_certificate.cert.arn
+    minimum_protocol_version = "TLSv1.2_2018"
+    ssl_support_method       = "sni-only"
+  }
+}

--- a/terraform/environment/main.tf
+++ b/terraform/environment/main.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  alias = "us"
+}

--- a/terraform/environment/route53.tf
+++ b/terraform/environment/route53.tf
@@ -1,0 +1,46 @@
+locals {
+  subdomain = "${var.environment}.${var.domain_name}"
+}
+
+data "aws_route53_zone" "root" {
+  name = var.domain_name
+}
+
+resource "aws_acm_certificate" "cert" {
+  provider = "aws.us"
+
+  domain_name               = local.subdomain
+  subject_alternative_names = ["*.${local.subdomain}"]
+  validation_method         = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "cert_validation" {
+  name    = aws_acm_certificate.cert.domain_validation_options.0.resource_record_name
+  type    = aws_acm_certificate.cert.domain_validation_options.0.resource_record_type
+  zone_id = data.aws_route53_zone.root.id
+  records = [aws_acm_certificate.cert.domain_validation_options.0.resource_record_value]
+  ttl     = 60
+}
+
+resource "aws_acm_certificate_validation" "cert" {
+  provider = "aws.us"
+
+  certificate_arn         = aws_acm_certificate.cert.arn
+  validation_record_fqdns = [aws_route53_record.cert_validation.fqdn]
+}
+
+resource "aws_route53_record" "cloudfront" {
+  zone_id = data.aws_route53_zone.root.zone_id
+  name    = "*.${local.subdomain}"
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.main.domain_name
+    zone_id                = aws_cloudfront_distribution.main.hosted_zone_id
+    evaluate_target_health = true
+  }
+}

--- a/terraform/environment/variables.tf
+++ b/terraform/environment/variables.tf
@@ -1,0 +1,9 @@
+variable "environment" {
+  type        = string
+  description = "Environment name (for example: staging)"
+}
+
+variable "domain_name" {
+  type        = string
+  description = "Root domain name"
+}

--- a/terraform/site.tf
+++ b/terraform/site.tf
@@ -1,0 +1,47 @@
+terraform {
+  backend "s3" {
+    bucket = "govuk-pay-terraform-state"
+    key    = "tfstate"
+    region = "eu-west-2"
+  }
+}
+
+provider "aws" {
+  version = "~> 2.0"
+  region  = "eu-west-2"
+}
+
+provider "aws" {
+  version = "~> 2.0"
+  region  = "us-east-1"
+  alias   = "us"
+}
+
+resource "aws_s3_bucket" "tfstate" {
+  bucket = "govuk-pay-terraform-state"
+  acl    = "private"
+
+  versioning {
+    enabled = true
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "aws:kms"
+      }
+    }
+  }
+}
+
+module "staging" {
+  source = "./environment"
+
+  providers = {
+    aws    = "aws"
+    aws.us = "aws.us"
+  }
+
+  environment = "staging"
+  domain_name = "gdspay.uk"
+}


### PR DESCRIPTION
I've created two TF modules:

- `dns` manages Route53 for the root domain name.
- `environment` holds configuration for a Pay environment (for example,
  staging).

Inside `environment` we setup a Cloudfront distribution to forward
traffic to the PaaS and some Route53 records to setup the environment's
subdomain and an ALIAS record to the Cloudfront distribution.

Cloudfront can only use ACM certificates that were provisioned in
us-east-1, so we need to provide an additional aliased `aws` provider to
the `environment` module that can be used for provisioning that cert.