### PR TITLE
PP-5894: Forward Authorization headers to PaaS from CloudFront

### DIFF
--- a/terraform/environment/cloudfront.tf
+++ b/terraform/environment/cloudfront.tf
@@ -24,7 +24,7 @@ resource "aws_cloudfront_distribution" "main" {
     default_ttl            = 0
 
     forwarded_values {
-      headers      = ["Host", "Origin"]
+      headers      = ["Host", "Origin", "Authorization"]
       query_string = true
       cookies {
         forward = "all"


### PR DESCRIPTION
Ensures authenticated GET requests reach PaaS, particularly publicapi.
We could potentially create another behaviour rule for this to apply to only `/v1/*` routes, but this will work.