### PR TITLE
PP-5907: Create separate staging deploy pipeline

### DIFF
--- a/ci/config/space-users/staging.csv
+++ b/ci/config/space-users/staging.csv
@@ -1,8 +1,0 @@
-Username,Password,Org,Space,OrgManager,BillingManager,OrgAuditor,SpaceManager,SpaceDeveloper,SpaceAuditor
-106981284630415421896,,$ORG,$SPACE,,,,,,y
-dan.worth@digital.cabinet-office.gov.uk,,$ORG,$SPACE,,,,,,y
-dominic.jones@digital.cabinet-office.gov.uk,,$ORG,$SPACE,,,,,,y
-richard.baker@digital.cabinet-office.gov.uk,,$ORG,$SPACE,,,,,,y
-stephen.daly@digital.cabinet-office.gov.uk,,$ORG,$SPACE,,,,,,y
-oswald.quek@digital.cabinet-office.gov.uk,,$ORG,$SPACE,,,,,,y
-nimalan.kirubakaran@digital.cabinet-office.gov.uk,,$ORG,$SPACE,,,,,,y

--- a/ci/pipelines/deploy.yml
+++ b/ci/pipelines/deploy.yml
@@ -1,0 +1,270 @@
+---
+resource_types:
+  - name: cf-cli
+    type: docker-image
+    source:
+      repository: nulldriver/cf-cli-resource
+
+resources:
+  - name: omnibus
+    type: git
+    icon: github-circle
+    source:
+      uri: https://github.com/alphagov/pay-omnibus
+      branch: develop
+
+  - name: paas-staging
+    type: cf-cli
+    icon: cloud-upload-outline
+    source:
+      api: https://api.london.cloud.service.gov.uk
+      org: govuk-pay
+      space: staging
+      username: ((cf-username))
+      password: ((cf-password))
+
+  - &image
+    name: adminusers
+    type: registry-image
+    icon: docker
+    source: &image-source
+      repository: govukpay/adminusers
+      tag: latest-master
+      username: ((docker-username))
+      password: ((docker-password))
+
+  - <<: *image
+    name: cardid
+    source:
+      <<: *image-source
+      repository: govukpay/cardid
+
+  - <<: *image
+    name: card-connector
+    source:
+      <<: *image-source
+      repository: govukpay/connector
+
+  - <<: *image
+    name: directdebit-connector
+    source:
+      <<: *image-source
+      repository: govukpay/directdebit-connector
+
+  - <<: *image
+    name: directdebit-frontend
+    source:
+      <<: *image-source
+      repository: govukpay/directdebit-frontend
+
+  - <<: *image
+    name: card-frontend
+    source:
+      <<: *image-source
+      repository: govukpay/frontend
+
+  - <<: *image
+    name: ledger
+    source:
+      <<: *image-source
+      repository: govukpay/ledger
+
+  - <<: *image
+    name: products
+    source:
+      <<: *image-source
+      repository: govukpay/products
+
+  - <<: *image
+    name: products-ui
+    source:
+      <<: *image-source
+      repository: govukpay/products-ui
+
+  - <<: *image
+    name: publicapi
+    source:
+      <<: *image-source
+      repository: govukpay/publicapi
+
+  - <<: *image
+    name: publicauth
+    source:
+      <<: *image-source
+      repository: govukpay/publicauth
+
+  - <<: *image
+    name: selfservice
+    source:
+      <<: *image-source
+      repository: govukpay/selfservice
+
+  - <<: *image
+    name: notifications
+    source:
+      <<: *image-source
+      repository: govukpaypaas/notifications
+
+jobs:
+  - name: deploy-adminusers-staging
+    serial_groups: [adminusers]
+    plan:
+      - get: omnibus
+      - get: adminusers
+        trigger: true
+      - put: app
+        resource: paas-staging
+        params: &paas-app
+          command: push
+          app_name: adminusers
+          manifest: omnibus/paas/pay-apps.yml
+          docker_password: ((docker-password))
+          vars:
+            space: staging
+            docker-username: ((docker-username))
+          vars_files:
+            - omnibus/paas/env_variables/staging.yml
+
+  - name: deploy-cardid-staging
+    serial_groups: [cardid]
+    plan:
+      - get: omnibus
+      - get: cardid
+        trigger: true
+      - put: app
+        resource: paas
+        params:
+          <<: *paas-app
+          app_name: cardid
+
+  - name: deploy-card-connector-staging
+    serial_groups: [card-connector]
+    plan:
+      - get: omnibus
+      - get: card-connector
+        trigger: true
+      - put: app
+        resource: paas
+        params:
+          <<: *paas-app
+          app_name: card-connector
+
+  - name: deploy-card-frontend-staging
+    serial_groups: [card-frontend]
+    plan:
+      - get: omnibus
+      - get: card-frontend
+        trigger: true
+      - put: app
+        resource: paas
+        params:
+          <<: *paas-app
+          app_name: card-frontend
+
+  - name: deploy-directdebit-connector-staging
+    serial_groups: [directdebit-connector]
+    plan:
+      - get: omnibus
+      - get: directdebit-connector
+        trigger: true
+      - put: app
+        resource: paas
+        params:
+          <<: *paas-app
+          app_name: directdebit-connector
+
+  - name: deploy-directdebit-frontend-staging
+    serial_groups: [directdebit-frontend]
+    plan:
+      - get: omnibus
+      - get: directdebit-frontend
+        trigger: true
+      - put: app
+        resource: paas
+        params:
+          <<: *paas-app
+          app_name: directdebit-frontend
+
+  - name: deploy-ledger-staging
+    serial_groups: [ledger]
+    plan:
+      - get: omnibus
+      - get: ledger
+        trigger: true
+      - put: app
+        resource: paas
+        params:
+          <<: *paas-app
+          app_name: ledger
+
+  - name: deploy-products-staging
+    serial_groups: [products]
+    plan:
+      - get: omnibus
+      - get: products
+        trigger: true
+      - put: app
+        resource: paas
+        params:
+          <<: *paas-app
+          app_name: products
+
+  - name: deploy-products-ui-staging
+    serial_groups: [products-ui]
+    plan:
+      - get: omnibus
+      - get: products-ui
+        trigger: true
+      - put: app
+        resource: paas
+        params:
+          <<: *paas-app
+          app_name: products-ui
+
+  - name: deploy-publicapi-staging
+    serial_groups: [publicapi]
+    plan:
+      - get: omnibus
+      - get: publicapi
+        trigger: true
+      - put: app
+        resource: paas
+        params:
+          <<: *paas-app
+          app_name: publicapi
+
+  - name: deploy-publicauth-staging
+    serial_groups: [publicauth]
+    plan:
+      - get: omnibus
+      - get: publicauth
+        trigger: true
+      - put: app
+        resource: paas
+        params:
+          <<: *paas-app
+          app_name: publicauth
+
+  - name: deploy-selfservice-staging
+    serial_groups: [selfservice]
+    plan:
+      - get: omnibus
+      - get: selfservice
+        trigger: true
+      - put: app
+        resource: paas
+        params:
+          <<: *paas-app
+          app_name: selfservice
+
+  - name: deploy-notifications-staging
+    serial_groups: [notifications]
+    plan:
+      - get: omnibus
+      - get: notifications
+        trigger: true
+      - put: app
+        resource: paas
+        params:
+          <<: *paas-app
+          app_name: notifications

--- a/ci/pipelines/deploy.yml
+++ b/ci/pipelines/deploy.yml
@@ -132,7 +132,7 @@ jobs:
       - get: cardid
         trigger: true
       - put: app
-        resource: paas
+        resource: paas-staging
         params:
           <<: *paas-app
           app_name: cardid
@@ -144,7 +144,7 @@ jobs:
       - get: card-connector
         trigger: true
       - put: app
-        resource: paas
+        resource: paas-staging
         params:
           <<: *paas-app
           app_name: card-connector
@@ -156,7 +156,7 @@ jobs:
       - get: card-frontend
         trigger: true
       - put: app
-        resource: paas
+        resource: paas-staging
         params:
           <<: *paas-app
           app_name: card-frontend
@@ -168,7 +168,7 @@ jobs:
       - get: directdebit-connector
         trigger: true
       - put: app
-        resource: paas
+        resource: paas-staging
         params:
           <<: *paas-app
           app_name: directdebit-connector
@@ -180,7 +180,7 @@ jobs:
       - get: directdebit-frontend
         trigger: true
       - put: app
-        resource: paas
+        resource: paas-staging
         params:
           <<: *paas-app
           app_name: directdebit-frontend
@@ -192,7 +192,7 @@ jobs:
       - get: ledger
         trigger: true
       - put: app
-        resource: paas
+        resource: paas-staging
         params:
           <<: *paas-app
           app_name: ledger
@@ -204,7 +204,7 @@ jobs:
       - get: products
         trigger: true
       - put: app
-        resource: paas
+        resource: paas-staging
         params:
           <<: *paas-app
           app_name: products
@@ -216,7 +216,7 @@ jobs:
       - get: products-ui
         trigger: true
       - put: app
-        resource: paas
+        resource: paas-staging
         params:
           <<: *paas-app
           app_name: products-ui
@@ -228,7 +228,7 @@ jobs:
       - get: publicapi
         trigger: true
       - put: app
-        resource: paas
+        resource: paas-staging
         params:
           <<: *paas-app
           app_name: publicapi
@@ -240,7 +240,7 @@ jobs:
       - get: publicauth
         trigger: true
       - put: app
-        resource: paas
+        resource: paas-staging
         params:
           <<: *paas-app
           app_name: publicauth
@@ -252,7 +252,7 @@ jobs:
       - get: selfservice
         trigger: true
       - put: app
-        resource: paas
+        resource: paas-staging
         params:
           <<: *paas-app
           app_name: selfservice
@@ -264,7 +264,7 @@ jobs:
       - get: notifications
         trigger: true
       - put: app
-        resource: paas
+        resource: paas-staging
         params:
           <<: *paas-app
           app_name: notifications

--- a/ci/pipelines/deploy.yml
+++ b/ci/pipelines/deploy.yml
@@ -1,4 +1,46 @@
 ---
+groups:
+  - name: All
+    jobs:
+      - deploy-adminusers-staging
+      - deploy-cardid-staging
+      - deploy-card-connector-staging
+      - deploy-card-frontend-staging
+      - deploy-directdebit-connector-staging
+      - deploy-directdebit-frontend-staging
+      - deploy-ledger-staging
+      - deploy-products-staging
+      - deploy-products-ui-staging
+      - deploy-publicapi-staging
+      - deploy-publicauth-staging
+      - deploy-selfservice-staging
+      - deploy-notifications-staging
+      - card-payment-smoke-tests-staging
+      - direct-debit-smoke-tests-staging
+      - products-smoke-test-staging
+
+  - name: Staging Deploys
+    jobs:
+      - deploy-adminusers-staging
+      - deploy-cardid-staging
+      - deploy-card-connector-staging
+      - deploy-card-frontend-staging
+      - deploy-directdebit-connector-staging
+      - deploy-directdebit-frontend-staging
+      - deploy-ledger-staging
+      - deploy-products-staging
+      - deploy-products-ui-staging
+      - deploy-publicapi-staging
+      - deploy-publicauth-staging
+      - deploy-selfservice-staging
+      - deploy-notifications-staging
+
+  - name: Staging Smoke Tests
+    jobs:
+      - card-payment-smoke-tests-staging
+      - direct-debit-smoke-tests-staging
+      - products-smoke-test-staging
+
 resource_types:
   - name: cf-cli
     type: docker-image

--- a/ci/pipelines/deploy.yml
+++ b/ci/pipelines/deploy.yml
@@ -25,7 +25,7 @@ resources:
 
   - &image
     name: adminusers
-    type: registry-image
+    type: docker-image
     icon: docker
     source: &image-source
       repository: govukpay/adminusers
@@ -107,11 +107,13 @@ resources:
 
 jobs:
   - name: deploy-adminusers-staging
-    serial_groups: [adminusers]
+    serial_groups: [adminusers-stg]
     plan:
       - get: omnibus
       - get: adminusers
         trigger: true
+        params:
+          skip_download: true
       - put: app
         resource: paas-staging
         params: &paas-app
@@ -126,11 +128,13 @@ jobs:
             - omnibus/paas/env_variables/staging.yml
 
   - name: deploy-cardid-staging
-    serial_groups: [cardid]
+    serial_groups: [cardid-stg]
     plan:
       - get: omnibus
       - get: cardid
         trigger: true
+        params:
+          skip_download: true
       - put: app
         resource: paas-staging
         params:
@@ -138,11 +142,13 @@ jobs:
           app_name: cardid
 
   - name: deploy-card-connector-staging
-    serial_groups: [card-connector]
+    serial_groups: [card-connector-stg]
     plan:
       - get: omnibus
       - get: card-connector
         trigger: true
+        params:
+          skip_download: true
       - put: app
         resource: paas-staging
         params:
@@ -150,11 +156,13 @@ jobs:
           app_name: card-connector
 
   - name: deploy-card-frontend-staging
-    serial_groups: [card-frontend]
+    serial_groups: [card-frontend-stg]
     plan:
       - get: omnibus
       - get: card-frontend
         trigger: true
+        params:
+          skip_download: true
       - put: app
         resource: paas-staging
         params:
@@ -162,11 +170,13 @@ jobs:
           app_name: card-frontend
 
   - name: deploy-directdebit-connector-staging
-    serial_groups: [directdebit-connector]
+    serial_groups: [directdebit-connector-stg]
     plan:
       - get: omnibus
       - get: directdebit-connector
         trigger: true
+        params:
+          skip_download: true
       - put: app
         resource: paas-staging
         params:
@@ -174,11 +184,13 @@ jobs:
           app_name: directdebit-connector
 
   - name: deploy-directdebit-frontend-staging
-    serial_groups: [directdebit-frontend]
+    serial_groups: [directdebit-frontend-stg]
     plan:
       - get: omnibus
       - get: directdebit-frontend
         trigger: true
+        params:
+          skip_download: true
       - put: app
         resource: paas-staging
         params:
@@ -186,11 +198,13 @@ jobs:
           app_name: directdebit-frontend
 
   - name: deploy-ledger-staging
-    serial_groups: [ledger]
+    serial_groups: [ledger-stg]
     plan:
       - get: omnibus
       - get: ledger
         trigger: true
+        params:
+          skip_download: true
       - put: app
         resource: paas-staging
         params:
@@ -198,11 +212,13 @@ jobs:
           app_name: ledger
 
   - name: deploy-products-staging
-    serial_groups: [products]
+    serial_groups: [products-stg]
     plan:
       - get: omnibus
       - get: products
         trigger: true
+        params:
+          skip_download: true
       - put: app
         resource: paas-staging
         params:
@@ -210,11 +226,13 @@ jobs:
           app_name: products
 
   - name: deploy-products-ui-staging
-    serial_groups: [products-ui]
+    serial_groups: [products-ui-stg]
     plan:
       - get: omnibus
       - get: products-ui
         trigger: true
+        params:
+          skip_download: true
       - put: app
         resource: paas-staging
         params:
@@ -222,11 +240,13 @@ jobs:
           app_name: products-ui
 
   - name: deploy-publicapi-staging
-    serial_groups: [publicapi]
+    serial_groups: [publicapi-stg]
     plan:
       - get: omnibus
       - get: publicapi
         trigger: true
+        params:
+          skip_download: true
       - put: app
         resource: paas-staging
         params:
@@ -234,11 +254,13 @@ jobs:
           app_name: publicapi
 
   - name: deploy-publicauth-staging
-    serial_groups: [publicauth]
+    serial_groups: [publicauth-stg]
     plan:
       - get: omnibus
       - get: publicauth
         trigger: true
+        params:
+          skip_download: true
       - put: app
         resource: paas-staging
         params:
@@ -246,11 +268,13 @@ jobs:
           app_name: publicauth
 
   - name: deploy-selfservice-staging
-    serial_groups: [selfservice]
+    serial_groups: [selfservice-stg]
     plan:
       - get: omnibus
       - get: selfservice
         trigger: true
+        params:
+          skip_download: true
       - put: app
         resource: paas-staging
         params:
@@ -258,13 +282,93 @@ jobs:
           app_name: selfservice
 
   - name: deploy-notifications-staging
-    serial_groups: [notifications]
+    serial_groups: [notifications-stg]
     plan:
       - get: omnibus
       - get: notifications
         trigger: true
+        params:
+          skip_download: true
       - put: app
         resource: paas-staging
         params:
           <<: *paas-app
           app_name: notifications
+
+  - name: card-payment-smoke-tests-staging
+    serial_groups: [cardid-stg, card-connector-stg, card-frontend-stg, ledger-stg, publicapi-stg, publicauth-stg]
+    plan:
+      - get: omnibus
+      - &trigger-test
+        get: cardid
+        passed: [deploy-cardid-staging]
+        trigger: true
+        params:
+          skip_download: true
+      - <<: *trigger-test
+        get: card-connector
+        passed: [deploy-card-connector-staging]
+      - <<: *trigger-test
+        get: card-frontend
+        passed: [deploy-card-frontend-staging]
+      - <<: *trigger-test
+        get: ledger
+        passed: [deploy-ledger-staging]
+      - <<: *trigger-test
+        get: publicapi
+        passed: [deploy-publicapi-staging]
+      - <<: *trigger-test
+        get: publicauth
+        passed: [deploy-publicauth-staging]
+      - task: run card smoke test
+        file: omnibus/ci/tasks/cf-task.yml
+        params:
+          CF_ORG: govuk-pay
+          CF_SPACE: tools
+          COMMAND: cf ssh endtoend -c /app/bin/smoke-cardp1
+
+  - name: direct-debit-smoke-tests-staging
+    serial_groups: [adminusers-stg, directdebit-connector-stg, directdebit-frontend-stg, ledger-stg, publicapi-stg, publicauth-stg]
+    plan:
+      - get: omnibus
+      - <<: *trigger-test
+        get: adminusers
+        passed: [deploy-adminusers-staging]
+      - <<: *trigger-test
+        get: directdebit-connector
+        passed: [deploy-directdebit-connector-staging]
+      - <<: *trigger-test
+        get: directdebit-frontend
+        passed: [deploy-directdebit-frontend-staging]
+      - <<: *trigger-test
+        get: ledger
+        passed: [deploy-ledger-staging]
+      - <<: *trigger-test
+        get: publicapi
+        passed: [deploy-publicapi-staging]
+      - <<: *trigger-test
+        get: publicauth
+        passed: [deploy-publicauth-staging]
+      - task: run direct debit smoke test
+        file: omnibus/ci/tasks/cf-task.yml
+        params:
+          CF_ORG: govuk-pay
+          CF_SPACE: tools
+          COMMAND: cf ssh endtoend -c /app/bin/smoke-directdebitp1
+
+  - name: products-smoke-test-staging
+    serial_groups: [products-stg, products-ui-stg]
+    plan:
+      - get: omnibus
+      - <<: *trigger-test
+        get: products
+        passed: [deploy-products-staging]
+      - <<: *trigger-test
+        get: products-ui
+        passed: [deploy-products-ui-staging]
+      - task: run products smoke test
+        file: omnibus/ci/tasks/cf-task.yml
+        params:
+          CF_ORG: govuk-pay
+          CF_SPACE: tools
+          COMMAND: cf ssh endtoend -c /app/bin/smoke-products


### PR DESCRIPTION
This change adds a new `deploy.yml` pipeline. This is used to deploy built artefacts for each application to the Staging PaaS environment. This also decouples the staging environment CF space definition from the dev environment spaces.

At a later point this pipeline may be updated to further promote built artefacts to a production environment following successful deployment validation (smoke tests etc).

Currently, application deploys are triggered by changes to an application Docker image tagged with `latest-master`. This may later be changed to respond to git tags promoting a build from a successful CI test stage.

<img width="754" alt="Screenshot 2019-12-10 at 13 51 59" src="https://user-images.githubusercontent.com/783245/70535251-9ccb6680-1b54-11ea-9642-be597fd5fe13.png">

