### PR TITLE
Ensure CloudFront distribution is created after ACM cert validation

### DIFF
--- a/terraform/modules/environment/cloudfront.tf
+++ b/terraform/modules/environment/cloudfront.tf
@@ -4,8 +4,11 @@ resource "aws_s3_bucket" "cloudfront_logs" {
 }
 
 resource "aws_cloudfront_distribution" "main" {
-  enabled = "${var.enable_cloudfront}"
-  comment = "cloudfront-${var.environment}"
+  enabled    = "${var.enable_cloudfront}"
+  comment    = "cloudfront-${var.environment}"
+  depends_on = [
+    "${aws_acm_certificate_validation.cert}",
+  ]
 
   logging_config {
     include_cookies = false


### PR DESCRIPTION
Specifies a dependency on the SSL certificate validation before the CloudFront distribution is created. Without this Terraform fails to create the distribution because the certificate is not
yet validated.