### PR TITLE
PP-6030 Switch card-frontend to deploy from buildpack

### DIFF
--- a/ci/pipelines/deploy.yml
+++ b/ci/pipelines/deploy.yml
@@ -71,6 +71,17 @@ resources:
           username: pay-deploy
           password: ((readonly_local_user_password))
 
+  - name: git-card-frontend-pre-release
+    type: github-release
+    source:
+      owner: alphagov
+      access-token: ((github-access-token))
+      tag_filter: "paas_release-(.*)"
+      order_by: version
+      repository: pay-frontend
+      pre_release: true
+      release: false
+
   - &image
     name: adminusers
     type: docker-image
@@ -104,12 +115,6 @@ resources:
     source:
       <<: *image-source
       repository: govukpay/directdebit-frontend
-
-  - <<: *image
-    name: card-frontend
-    source:
-      <<: *image-source
-      repository: govukpay/frontend
 
   - <<: *image
     name: ledger
@@ -259,16 +264,22 @@ jobs:
     serial_groups: [card-frontend-stg]
     plan:
       - get: omnibus
-      - get: card-frontend
+      - get: git-card-frontend-pre-release
         trigger: true
+      - task: download-card-frontend-artifact
+        file: omnibus/ci/tasks/download-deployment-artifact.yml
+        input_mapping: { git-release: git-card-frontend-pre-release }
+        output_mapping: { artifact: card-frontend-artifact }
+      - put: cf-cli
         params:
-          skip_download: true
-      - put: app
-        resource: paas-staging
-        params:
-          <<: *paas-app
-          app_name: card-frontend
-          space: staging-cde
+          command: push
+          path: card-frontend-artifact
+          manifest: card-frontend-artifact/manifest.yml
+          vars_files:
+            - omnibus/paas/env_variables/staging.yml
+          vars:
+            memory: 1G
+            disk_quota: 1G
 
   - name: deploy-directdebit-connector-staging
     serial_groups: [directdebit-connector-stg]

--- a/ci/tasks/download-deployment-artifact.yml
+++ b/ci/tasks/download-deployment-artifact.yml
@@ -1,0 +1,20 @@
+platform: linux
+
+image_resource:
+  type: registry-image
+  source:
+    repository: alpine
+
+inputs:
+  - name: git-release
+    optional: false
+
+outputs:
+  - name: artifact
+
+run:
+  path: sh
+  args:
+    - -c
+    - |
+      tar -C artifact -xf git-release/pay-*-*.tar.gz

--- a/paas/env_variables/staging.yml
+++ b/paas/env_variables/staging.yml
@@ -15,3 +15,8 @@ directdebit_frontend_url: directdebit-frontend.staging.gdspay.uk
 notifications_url: notifications.staging.gdspay.uk
 products_ui_url: products.staging.gdspay.uk
 db_ssl: 'true'
+card_connector_analytics_tracking_id: testing-123
+adminusers_url: adminusers-staging.apps.internal
+card_connector_url: card-connector-staging.apps.internal
+cardid_url: cardid-staging.apps.internal
+card_frontend_session_encryption_key: asdjhbwefbo23r23rbfik2roiwhefwbqw


### PR DESCRIPTION
Add a github-release resource to watch for releases with appropriate
tag. Once triggered the `download_deployment_artifact.yml` task will get the
zipped archive and extract it so that the `cf` resource can push it
using the included manifest.

This commit will require a new credential on concourse for the github
api token, referred to within the deploy job as `git-access-token`.

**What**
I've tested something very similar on a local pipeline pushing to my dev space so should work. Just doing it for Frontend to begin with.

~This is dependent upon Richard's work and adding the new github access token cred to concourse, hence the `do-not-merge`.
https://github.com/alphagov/pay-omnibus/pull/45#pullrequestreview-347990689~ Richard's pr is merged.