### PR TITLE
PP-6030 Correct config errors

### DIFF
--- a/ci/pipelines/deploy.yml
+++ b/ci/pipelines/deploy.yml
@@ -270,7 +270,7 @@ jobs:
         file: omnibus/ci/tasks/download-deployment-artifact.yml
         input_mapping: { git-release: git-card-frontend-pre-release }
         output_mapping: { artifact: card-frontend-artifact }
-      - put: cf-cli
+      - put: paas-staging
         params:
           command: push
           path: card-frontend-artifact
@@ -517,7 +517,7 @@ jobs:
         get: card-connector
         passed: [deploy-card-connector-staging]
       - <<: *trigger-test
-        get: card-frontend
+        get: git-card-frontend-pre-release
         passed: [deploy-card-frontend-staging]
       - <<: *trigger-test
         get: ledger


### PR DESCRIPTION
cf-cli resources is the type not the name, which is `paas-staging`.
Remove old card-frontend docker image resource as a trigger for smoke
tests.