### PR TITLE
PP-6030 Correct env vars for staging

### DIFF
--- a/paas/env_variables/staging.yml
+++ b/paas/env_variables/staging.yml
@@ -16,7 +16,7 @@ notifications_url: notifications.staging.gdspay.uk
 products_ui_url: products.staging.gdspay.uk
 db_ssl: 'true'
 card_connector_analytics_tracking_id: testing-123
-adminusers_url: adminusers-staging.apps.internal
-card_connector_url: card-connector-staging.apps.internal
-cardid_url: cardid-staging.apps.internal
+adminusers_url: http://adminusers-staging.apps.internal:8080
+card_connector_url: http://card-connector-staging.apps.internal:8080
+cardid_url: http://cardid-staging.apps.internal:8080
 card_frontend_session_encryption_key: asdjhbwefbo23r23rbfik2roiwhefwbqw


### PR DESCRIPTION
In the new individual manifests we are no longer using the format
`http://((app_route)):8080` so the urls in the config need to be
updated. I've tried manually changing the env vars for card-frontend to
those included in here and the smoke tests pass.

We may have some inconsistency as we move to individual manifests and
buildpacks whether the manfiest expects the protocol prefix or not, if
things break we can fix it up.