### PR TITLE
PP-6030 Add manifest param back

### DIFF
--- a/ci/pipelines/deploy.yml
+++ b/ci/pipelines/deploy.yml
@@ -273,6 +273,7 @@ jobs:
         params: &push-app-config
           command: push
           path: artefact
+          manifest: artefact/manifest.yml
           vars_files:
             - omnibus/paas/env_variables/staging.yml
           vars:


### PR DESCRIPTION
It was thought this wasn't needed with the cf-cli, we were wrong.