### PR TITLE
PP-6030_update_staging_vars

### DIFF
--- a/ci/tasks/extract-artefact.yml
+++ b/ci/tasks/extract-artefact.yml
@@ -17,4 +17,4 @@ run:
   args:
     - -c
     - |
-      tar -C artefact -xf git-release/pay-*-*.tar.gz
+      tar -C artefact -xf git-release/pay-*.tar.gz

--- a/paas/env_variables/staging.yml
+++ b/paas/env_variables/staging.yml
@@ -25,3 +25,9 @@ products_url: http://products-staging.apps.internal:8080
 selfservice_transactions_url: https://selfservice.staging.gdspay.uk/transactions
 session_encryption_key: asdjhbwefbo23r23rbfik2roiwhefwbqw
 selfservice_encryption_key: asdjhbwefbo23r23rbfik2roiwhefwbqw
+analytics_tracking_id: testing-123
+disable_appmetrics: true
+disable_request_logging: false
+metrics_host: https://test.test
+products_ui_route: products.staging.gdspay.uk
+


### PR DESCRIPTION
Update staging.yml with missing vars for node apps. This is a temp fix
to get to a point where the apps will run.

Update the extract-artefact task since direct-debit-frontend.tar.gz
isn't caught by the current pattern.