### PR TITLE
Get create test user working

### DIFF
--- a/ci/pipelines/dev-env.yml
+++ b/ci/pipelines/dev-env.yml
@@ -178,7 +178,7 @@ jobs:
         params:
           CF_ORG: govuk-pay
           CF_SPACE: ((space))
-          ARGS: user
+          ARGS: user a-test-user 'Pay for a thing'
 
   - name: deploy-adminusers
     serial_groups: [adminusers]


### PR DESCRIPTION
Get create test user working temporarily by passing in a user and
service name, as these are now expected as arguments.