### PR TITLE
PP-6031 Copy yaml and yml to the archive

### DIFF
--- a/ci/tasks/maven-build.yml
+++ b/ci/tasks/maven-build.yml
@@ -41,4 +41,4 @@ run:
       archive_path="../build-output/${APP_NAME}-${release_number}.tar.gz"
 
       echo "Creating build archive in: ${archive_path}"
-      tar -czf "$archive_path" ./target/pay-*-allinone.jar ./target/*.yml
+      tar -czf "$archive_path" ./target/pay-*-allinone.jar ./target/*.y*l


### PR DESCRIPTION
When creating the tar for the release, copy files ending in both yml and
yaml since the manifest follows our convention of yml but the config
files use yaml; we don't want to change the config file extensions in
case it has unexpected consequences.