### PR TITLE
PP-6085 Add the env-map.yml to the release archive

### DIFF
--- a/ci/tasks/maven-build.yml
+++ b/ci/tasks/maven-build.yml
@@ -42,4 +42,4 @@ run:
 
       echo "Creating build archive in: ${archive_path}"
 
-      tar -czv -f "$archive_path" target/pay-*-allinone.jar manifest.yml
+      tar -czv -f "$archive_path" target/pay-*-allinone.jar manifest.yml env-map.yml


### PR DESCRIPTION
env-map.yml is used by the PaaS env-map-buildpack to flatten the VCAP services
vars for bound services on PaaS so that we don't have to change how our
apps consume env vars.