### PR TITLE
PP-6085 Add staging-cde creds

### DIFF
--- a/terraform/modules/paas/app-catalog-service.tf
+++ b/terraform/modules/paas/app-catalog-service.tf
@@ -1,31 +1,31 @@
 locals {
   app_catalog_urls = {
-    "adminusers_url"            = "http://${cloudfoundry_route.adminusers.endpoint}:8080"
-    "cardid_url"                = "http://${cloudfoundry_route.cardid.endpoint}:8080"
-    "card_connector_url"        = "http://${cloudfoundry_route.card_connector.endpoint}:8080"
-    "card_frontend_url"         = "https://${cloudfoundry_route.card_frontend.endpoint}"
-    "directdebit_connector_url" = "http://${cloudfoundry_route.directdebit_connector.endpoint}:8080"
-    "directdebit_frontend_url"  = "https://${cloudfoundry_route.directdebit_frontend.endpoint}"
-    "ledger_url"                = "http://${cloudfoundry_route.ledger.endpoint}:8080"
-    "notifications_url"         = "https://${cloudfoundry_route.notifications.endpoint}"
-    "products_ui_url"           = "https://${cloudfoundry_route.products_ui.endpoint}"
-    "products_url"              = "http://${cloudfoundry_route.products.endpoint}:8080"
-    "publicapi_url"             = "https://${cloudfoundry_route.publicapi.endpoint}"
-    "publicauth_url"            = "https://${cloudfoundry_route.publicauth.endpoint}"
-    "selfservice_url"           = "https://${cloudfoundry_route.selfservice.endpoint}"
+    "adminusers_url"               = "http://${cloudfoundry_route.adminusers.endpoint}:8080"
+    "cardid_url"                   = "http://${cloudfoundry_route.cardid.endpoint}:8080"
+    "card_connector_url"           = "http://${cloudfoundry_route.card_connector.endpoint}:8080"
+    "card_frontend_url"            = "https://${cloudfoundry_route.card_frontend.endpoint}"
+    "directdebit_connector_url"    = "http://${cloudfoundry_route.directdebit_connector.endpoint}:8080"
+    "directdebit_frontend_url"     = "https://${cloudfoundry_route.directdebit_frontend.endpoint}"
+    "ledger_url"                   = "http://${cloudfoundry_route.ledger.endpoint}:8080"
+    "notifications_url"            = "https://${cloudfoundry_route.notifications.endpoint}"
+    "products_ui_url"              = "https://${cloudfoundry_route.products_ui.endpoint}"
+    "products_url"                 = "http://${cloudfoundry_route.products.endpoint}:8080"
+    "publicapi_url"                = "https://${cloudfoundry_route.publicapi.endpoint}"
+    "publicauth_url"               = "https://${cloudfoundry_route.publicauth.endpoint}"
+    "selfservice_url"              = "https://${cloudfoundry_route.selfservice.endpoint}"
     "selfservice_transactions_url" = "https://${cloudfoundry_route.selfservice.endpoint}/transactions"
-    "toolbox_url"               = "https://${cloudfoundry_route.toolbox.endpoint}"
+    "toolbox_url"                  = "https://${cloudfoundry_route.toolbox.endpoint}"
   }
 }
 
 resource "cloudfoundry_user_provided_service" "app_catalog" {
-  name  = "app-catalog"
-  space = data.cloudfoundry_space.space.id
+  name        = "app-catalog"
+  space       = data.cloudfoundry_space.space.id
   credentials = local.app_catalog_urls
 }
 
 resource "cloudfoundry_user_provided_service" "app_catalog_cde" {
-  name  = "app-catalog"
-  space = data.cloudfoundry_space.cde_space.id
+  name        = "app-catalog"
+  space       = data.cloudfoundry_space.cde_space.id
   credentials = local.app_catalog_urls
 }

--- a/terraform/modules/paas/app-catalog-service.tf
+++ b/terraform/modules/paas/app-catalog-service.tf
@@ -1,7 +1,5 @@
-resource "cloudfoundry_user_provided_service" "app_catalog" {
-  name  = "app-catalog"
-  space = data.cloudfoundry_space.space.id
-  credentials = {
+locals {
+  app_catalog_urls = {
     "adminusers_url"            = "http://${cloudfoundry_route.adminusers.endpoint}:8080"
     "cardid_url"                = "http://${cloudfoundry_route.cardid.endpoint}:8080"
     "card_connector_url"        = "http://${cloudfoundry_route.card_connector.endpoint}:8080"
@@ -15,6 +13,19 @@ resource "cloudfoundry_user_provided_service" "app_catalog" {
     "publicapi_url"             = "https://${cloudfoundry_route.publicapi.endpoint}"
     "publicauth_url"            = "https://${cloudfoundry_route.publicauth.endpoint}"
     "selfservice_url"           = "https://${cloudfoundry_route.selfservice.endpoint}"
+    "selfservice_transactions_url" = "https://${cloudfoundry_route.selfservice.endpoint}/transactions"
     "toolbox_url"               = "https://${cloudfoundry_route.toolbox.endpoint}"
   }
+}
+
+resource "cloudfoundry_user_provided_service" "app_catalog" {
+  name  = "app-catalog"
+  space = data.cloudfoundry_space.space.id
+  credentials = local.app_catalog_urls
+}
+
+resource "cloudfoundry_user_provided_service" "app_catalog_cde" {
+  name  = "app-catalog"
+  space = data.cloudfoundry_space.cde_space.id
+  credentials = local.app_catalog_urls
 }


### PR DESCRIPTION
It isn't possible to bind services to apps in another space so this
creates a version of the app-catalog for the staging-cde space. This
also adds `selfservice_transactions_url` which is needed by products-ui.

## WHAT
We deployed this on Friday running tf on my machine but didn't actually get round to committing it.