### PR TITLE
Update Terraform Cloudfoundry provider to v0.11.0

### DIFF
--- a/terraform/dev-paas/site.tf
+++ b/terraform/dev-paas/site.tf
@@ -1,5 +1,5 @@
 provider "cloudfoundry" {
-  version = "0.10.0"
+  version = "0.11.0"
   api_url = "https://api.london.cloud.service.gov.uk"
 }
 

--- a/terraform/staging-paas/site.tf
+++ b/terraform/staging-paas/site.tf
@@ -1,5 +1,5 @@
 provider "cloudfoundry" {
-  version = "0.10.0"
+  version = "0.11.0"
   api_url = "https://api.cloud.service.gov.uk"
 }
 


### PR DESCRIPTION
Bumps the required Cloudfoundry provider version to v0.11.0 to support sso authentication.

See release notes: https://github.com/cloudfoundry-community/terraform-provider-cf/releases/tag/v0.11.0

**Note:** This will require the locally installed plugin to be updated

`curl -o ~/.terraform/plugins/terraform-provider-cloudfoundry_v0.11.0 https://github.com/cloudfoundry-community/terraform-provider-cf/releases/download/v0.11.0/terraform-provider-cloudfoundry_darwin_amd64`
