### PR TITLE
Fix release tag calculation

### DIFF
--- a/ci/tasks/checkout-commit.yml
+++ b/ci/tasks/checkout-commit.yml
@@ -27,7 +27,7 @@ run:
 
       # calculate next release number
       set +e
-      latest_release_number=$(git describe --tags --abbrev=0 --match "paas_release-*" | cut -d "-" -f 2 || true)
+      latest_release_number=$(git tag --list 'paas_release-*' | sort -nr | head -1 | cut -d "-" -f 2 || true)
       is_numeric=$(echo ${latest_release_number} | egrep -E '^[0-9]+$')
 
       if ! [ is_numeric ]; then


### PR DESCRIPTION
Git describe only returns a single tag which isn't always the one we need. Instead, list all tags and filter by paas_release prefix then sort to return the latest paas release tag. 