### PR TITLE
PP-6085: Add SQS user proviced service inside the CDE space

### DIFF
--- a/terraform/modules/paas-stub-sqs/sqs.tf
+++ b/terraform/modules/paas-stub-sqs/sqs.tf
@@ -37,11 +37,8 @@ resource "cloudfoundry_network_policy" "sqs" {
   }
 }
 
-resource "cloudfoundry_user_provided_service" "sqs" {
-  name  = "sqs"
-  space = data.cloudfoundry_space.space.id
-
-  credentials = {
+locals {
+  sqs_credentials = {
     access_key                    = "x"
     secret_key                    = "x"
     non_standard_service_endpoint = "true"
@@ -51,3 +48,18 @@ resource "cloudfoundry_user_provided_service" "sqs" {
     event_queue_url               = "http://${cloudfoundry_route.sqs.endpoint}:9324/queue/pay_event_queue"
   }
 }
+
+resource "cloudfoundry_user_provided_service" "sqs-cde" {
+  name  = "sqs"
+  space = data.cloudfoundry_space.cde_space.id
+
+  credentials = local.sqs_credentials
+}
+
+resource "cloudfoundry_user_provided_service" "sqs" {
+  name  = "sqs"
+  space = data.cloudfoundry_space.space.id
+
+  credentials = local.sqs_credentials
+}
+

--- a/terraform/modules/paas/adminusers.tf
+++ b/terraform/modules/paas/adminusers.tf
@@ -4,7 +4,7 @@ resource "cloudfoundry_app" "adminusers" {
   stopped = true
 
   lifecycle {
-    ignore_changes = [stopped]
+    ignore_changes = [stopped, health_check_type]
   }
 }
 

--- a/terraform/modules/paas/card-connector.tf
+++ b/terraform/modules/paas/card-connector.tf
@@ -4,7 +4,7 @@ resource "cloudfoundry_app" "card_connector" {
   stopped = true
 
   lifecycle {
-    ignore_changes = [stopped]
+    ignore_changes = [stopped, health_check_type]
   }
 }
 

--- a/terraform/modules/paas/card-frontend.tf
+++ b/terraform/modules/paas/card-frontend.tf
@@ -4,7 +4,7 @@ resource "cloudfoundry_app" "card_frontend" {
   stopped = true
 
   lifecycle {
-    ignore_changes = [stopped]
+    ignore_changes = [stopped, health_check_type]
   }
 }
 

--- a/terraform/modules/paas/cardid.tf
+++ b/terraform/modules/paas/cardid.tf
@@ -4,7 +4,7 @@ resource "cloudfoundry_app" "cardid" {
   stopped = true
 
   lifecycle {
-    ignore_changes = [stopped]
+    ignore_changes = [stopped, health_check_type]
   }
 }
 

--- a/terraform/modules/paas/directdebit-connector.tf
+++ b/terraform/modules/paas/directdebit-connector.tf
@@ -4,7 +4,7 @@ resource "cloudfoundry_app" "directdebit_connector" {
   stopped = true
 
   lifecycle {
-    ignore_changes = [stopped]
+    ignore_changes = [stopped, health_check_type]
   }
 }
 

--- a/terraform/modules/paas/directdebit-frontend.tf
+++ b/terraform/modules/paas/directdebit-frontend.tf
@@ -4,7 +4,7 @@ resource "cloudfoundry_app" "directdebit_frontend" {
   stopped = true
 
   lifecycle {
-    ignore_changes = [stopped]
+    ignore_changes = [stopped, health_check_type]
   }
 }
 

--- a/terraform/modules/paas/ledger.tf
+++ b/terraform/modules/paas/ledger.tf
@@ -4,7 +4,7 @@ resource "cloudfoundry_app" "ledger" {
   stopped = true
 
   lifecycle {
-    ignore_changes = [stopped]
+    ignore_changes = [stopped, health_check_type]
   }
 }
 

--- a/terraform/modules/paas/notifications.tf
+++ b/terraform/modules/paas/notifications.tf
@@ -4,7 +4,7 @@ resource "cloudfoundry_app" "notifications" {
   stopped = true
 
   lifecycle {
-    ignore_changes = [stopped]
+    ignore_changes = [stopped, health_check_type]
   }
 }
 

--- a/terraform/modules/paas/products-ui.tf
+++ b/terraform/modules/paas/products-ui.tf
@@ -4,7 +4,7 @@ resource "cloudfoundry_app" "products_ui" {
   stopped = true
 
   lifecycle {
-    ignore_changes = [stopped]
+    ignore_changes = [stopped, health_check_type]
   }
 }
 

--- a/terraform/modules/paas/products.tf
+++ b/terraform/modules/paas/products.tf
@@ -4,7 +4,7 @@ resource "cloudfoundry_app" "products" {
   stopped = true
 
   lifecycle {
-    ignore_changes = [stopped]
+    ignore_changes = [stopped, health_check_type]
   }
 }
 

--- a/terraform/modules/paas/publicapi.tf
+++ b/terraform/modules/paas/publicapi.tf
@@ -4,7 +4,7 @@ resource "cloudfoundry_app" "publicapi" {
   stopped = true
 
   lifecycle {
-    ignore_changes = [stopped]
+    ignore_changes = [stopped, health_check_type]
   }
 }
 

--- a/terraform/modules/paas/publicauth.tf
+++ b/terraform/modules/paas/publicauth.tf
@@ -4,7 +4,7 @@ resource "cloudfoundry_app" "publicauth" {
   stopped = true
 
   lifecycle {
-    ignore_changes = [stopped]
+    ignore_changes = [stopped, health_check_type]
   }
 }
 

--- a/terraform/modules/paas/selfservice.tf
+++ b/terraform/modules/paas/selfservice.tf
@@ -4,7 +4,7 @@ resource "cloudfoundry_app" "selfservice" {
   stopped = true
 
   lifecycle {
-    ignore_changes = [stopped]
+    ignore_changes = [stopped, health_check_type]
   }
 }
 

--- a/terraform/modules/paas/toolbox.tf
+++ b/terraform/modules/paas/toolbox.tf
@@ -4,7 +4,7 @@ resource "cloudfoundry_app" "toolbox" {
   stopped = true
 
   lifecycle {
-    ignore_changes = [stopped]
+    ignore_changes = [stopped, health_check_type]
   }
 }
 


### PR DESCRIPTION
This is needed if we want connector to be able to talk to SQS in a nice way.

When applying the terraform we also noticed a weird edge case where terraform
wanted to turn all the health_check_type's back to "port" from "http" - we
think that might be a bug in the provider, but we're working around it for now
by telling terraform to ignore_changes.