### PR TITLE
Add terraform remote state config for staging-paas

### DIFF
--- a/terraform/staging-paas/site.tf
+++ b/terraform/staging-paas/site.tf
@@ -1,3 +1,17 @@
+terraform {
+  required_version = ">= 0.12.0"
+
+  required_providers {
+    cloudfoundry = ">= 0.11.0"
+  }
+
+  backend "s3" {
+    bucket = "govuk-pay-terraform-state"
+    key    = "staging-paas"
+    region = "eu-west-2"
+  }
+}
+
 provider "cloudfoundry" {
   version = "0.11.0"
   api_url = "https://api.cloud.service.gov.uk"


### PR DESCRIPTION
Adds remote state configuration for Paas Cloudfoundry resources. This uses the same S3 bucket as the AWS infra.

To run the terraform, you'll need to set CF_USER & CF_PASSWORD as per the plugin guide: https://github.com/cloudfoundry-community/terraform-provider-cf/wiki/provider_config

In addition, you'll also need to run terraform with AWS creds, i.e. via aws-vault

e.g. `CF_USER=username; CF_PASSWORD=password; aws-vault exec <account> -- terraform apply`