### PR TITLE
PP-6085 Remove app url from staging.yml

### DIFF
--- a/paas/env_variables/staging.yml
+++ b/paas/env_variables/staging.yml
@@ -7,22 +7,10 @@ run_migration: 'true'
 http_proxy_port: '8080'
 http_proxy_host: egress-staging.apps.internal
 disable_internal_https: 'true'
-publicapi_url: publicapi.staging.gdspay.uk
-publicauth_url: publicauth.staging.gdspay.uk
-selfservice_url: selfservice.staging.gdspay.uk
-card_frontend_url: card-frontend.staging.gdspay.uk
-directdebit_frontend_url: directdebit-frontend.staging.gdspay.uk
-notifications_url: notifications.staging.gdspay.uk
-products_ui_url: products.staging.gdspay.uk
 db_ssl: 'true'
 card_connector_analytics_tracking_id: testing-123
 
-adminusers_url: http://adminusers-staging.apps.internal:8080
-card_connector_url: http://card-connector-staging.apps.internal:8080
-cardid_url: http://cardid-staging.apps.internal:8080
 card_frontend_session_encryption_key: asdjhbwefbo23r23rbfik2roiwhefwbqw
-products_url: http://products-staging.apps.internal:8080
-selfservice_transactions_url: https://selfservice.staging.gdspay.uk/transactions
 session_encryption_key: asdjhbwefbo23r23rbfik2roiwhefwbqw
 selfservice_encryption_key: asdjhbwefbo23r23rbfik2roiwhefwbqw
 analytics_tracking_id: testing-123
@@ -30,8 +18,6 @@ disable_appmetrics: true
 disable_request_logging: false
 metrics_host: localhost
 products_ui_route: products.staging.gdspay.uk
-direct_debit_connector_url: http://directdebit-connector-staging.apps.internal:8080
-ledger_url: http://ledger-staging.apps.internal:8080
 products_friendly_base_uri: https://products.staging.gdspay.uk/redirect
 selfservice_analytics_tracking_id: test123
 selfservice_analytics_tracking_id_xgov: test123
@@ -44,7 +30,6 @@ direct_debit_frontend_analytics_tracking_id: test123
 direct_debit_frontend_analytics_tracking_id_xgov: test123
 direct_debit_frontend_sentry_dsn: ''
 direct_debit_frontend_session_encryption_key: asdjhbwefbo23r23rbfik2roiwhefwbqw
-direct_debit_frontend_url: directdebit-frontend.staging.gdspay.uk
 space: staging
 db_password: mysecretpassword
 db_ssl_option: ssl=false


### PR DESCRIPTION
Each app should be binding to `app-catalog` service to get the urls for
other apps. There are no longer needed in the staging.yml