### PR TITLE
PP-6085 Update publicauth salt for staging

### DIFF
--- a/paas/env_variables/staging.yml
+++ b/paas/env_variables/staging.yml
@@ -50,7 +50,7 @@ redis_url: none
 token_api_hmac_secret: something
 
 # publicauth
-token_db_bcrypt_salt: something
+token_db_bcrypt_salt: $2a$12$ObOCg5Vq4gkz7XE6STcnae
 
 # adminusers
 adminusers_route: adminusers-staging.apps.internal


### PR DESCRIPTION
Seems this needs to be a valid bcrypt salt value. Generated a new one
locally and tested by setting in staging space.