### PR TITLE
Temporarily disable frontend field level encryption

### DIFF
--- a/terraform/modules/aws/card-frontend.tf
+++ b/terraform/modules/aws/card-frontend.tf
@@ -36,7 +36,7 @@ resource "aws_cloudfront_distribution" "card_frontend" {
     max_ttl                = 0
     default_ttl            = 0
 
-    field_level_encryption_id = data.external.card_frontend_fle_config.result["id"]
+    #field_level_encryption_id = data.external.card_frontend_fle_config.result["id"]
 
     forwarded_values {
       headers      = ["Host", "Origin", "Authorization"]


### PR DESCRIPTION
Disassociate FLE profile from frontend CDN until app development (FLE field decryption) is complete.