### PR TITLE
PP-6085: Remove price from smoketest adhoc product

### DIFF
--- a/ci/tasks/smoke-test-user.yml
+++ b/ci/tasks/smoke-test-user.yml
@@ -52,7 +52,7 @@ run:
       eval $(echo "$data" | jq -r 'to_entries | map("export \(.key|ascii_upcase)=\(.value)") | .[]')
 
       # Create a product for smoke tests
-      bundle exec ./client create_product "$CARD_SANDBOX_API_TOKEN" "Smoke Test" "smoke-test" "product-test-environment"
+      bundle exec ./client create_adhoc_product "$CARD_SANDBOX_API_TOKEN" "Smoke Test" "smoke-test" "product-test-environment"
 
       cf target -s "$CF_SPACE_TOOLS"
       cf create-user-provided-service "$SERVICE_NAME" -p "$data"

--- a/client/client
+++ b/client/client
@@ -146,11 +146,10 @@ class AppClient
         .merge(user_data)
   end
 
-  def self.create_product(api_token, service_name, service_name_path, product_name)
+  def self.create_adhoc_product(api_token, service_name, service_name_path, product_name)
     product_data = {
         pay_api_token: api_token,
         name: 'exampleName',
-        price: 100,
         gateway_account_id: 1,
         return_url: 'https://www.payments.service.gov.uk',
         service_name: service_name,


### PR DESCRIPTION
Adding a price to an adhoc product makes it a non-adhoc product.
Product smoke tests require an adhoc product in order to target the "price" field and enter an arbitrary product price.