### PR TITLE
Add external route to toolbox app

### DIFF
--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -19,3 +19,7 @@ data "cloudfoundry_domain" "internal" {
 data "cloudfoundry_domain" "external" {
   name = var.external_domain
 }
+
+data "cloudfoundry_domain" "paas_external" {
+  name = "cloudapps.digital"
+}

--- a/terraform/modules/paas/toolbox.tf
+++ b/terraform/modules/paas/toolbox.tf
@@ -9,8 +9,8 @@ resource "cloudfoundry_app" "toolbox" {
 }
 
 resource "cloudfoundry_route" "toolbox" {
-  domain   = data.cloudfoundry_domain.external.id
-  hostname = "toolbox${var.external_hostname_suffix}"
+  domain   = data.cloudfoundry_domain.paas_external.id
+  hostname = "toolbox${var.internal_hostname_suffix}"
   space    = data.cloudfoundry_space.space.id
 
   target {


### PR DESCRIPTION
Adds a PaaS-provided route to get access the toolbox app in the Staging environment. This will be accessible via the cloudapps.digital domain for now and provides https by default.

Todo:
- [ ] Add route service proxy to filter requests by whitelisted IP
- [ ] Add Cloudfront distro if we want to use a custom domain, this is required to support TLS