### PR TITLE
PP-6127 Add secret service for publicapi

### DIFF
--- a/terraform/modules/credentials/main.tf
+++ b/terraform/modules/credentials/main.tf
@@ -1,0 +1,17 @@
+locals {
+  /* This needs some careful checking. If keys() and values() do not 
+  return the corresponding hash keys and values in the same order then the
+  zipped result will have the wrong value for a key. Perhaps there's a better way*/
+  low_pass_values = zipmap(keys(data.pass_password.secret), values(data.pass_password.secret).*.password)
+}
+
+provider "pass" {
+  store_dir = "../../../pay-low-pass"
+  refresh_store = false
+}
+
+data "pass_password" "secret" {
+  for_each = var.pay_low_pass_secrets
+  path = each.value
+}
+

--- a/terraform/modules/credentials/outputs.tf
+++ b/terraform/modules/credentials/outputs.tf
@@ -1,0 +1,4 @@
+output "secrets" {
+  sensitive = true
+  value = local.low_pass_values
+}

--- a/terraform/modules/credentials/variables.tf
+++ b/terraform/modules/credentials/variables.tf
@@ -1,0 +1,4 @@
+variable "pay_low_pass_secrets" {
+  type = map(string)
+}
+

--- a/terraform/modules/paas/publicapi.tf
+++ b/terraform/modules/paas/publicapi.tf
@@ -35,3 +35,14 @@ resource "cloudfoundry_network_policy" "publicapi" {
     port            = "8080"
   }
 }
+
+module "publicapi_credentials" {
+  source = "../credentials"
+  pay_low_pass_secrets = lookup(var.publicapi_credentials, "pay_low_pass_secrets")
+}
+
+resource "cloudfoundry_user_provided_service" "publicapi_secret_service" {
+  name        = "publicapi-serect-service"
+  space       = data.cloudfoundry_space.space.id
+  credentials = merge(module.publicapi_credentials.secrets, lookup(var.publicapi_credentials, "static_values"))
+}

--- a/terraform/modules/paas/variables.tf
+++ b/terraform/modules/paas/variables.tf
@@ -24,3 +24,8 @@ variable "external_hostname_suffix" {
   description = "Suffix to avoid route collisions when multiple spaces share the same domain (for example, -bob would give card-frontend-bob.cloudapps.digital and so on)"
   default     = ""
 }
+
+variable "publicapi_credentials" {
+  type        = map(map(string))
+  description = "credential for publicapi"
+}

--- a/terraform/staging-paas/site.tf
+++ b/terraform/staging-paas/site.tf
@@ -25,6 +25,7 @@ module "paas" {
   external_domain          = "staging.gdspay.uk"
   external_hostname_suffix = ""
   internal_hostname_suffix = "-stg"
+  publicapi_credentials = var.publicapi_credentials
 }
 
 module "paas_postgres" {

--- a/terraform/staging-paas/terraform.tfvars
+++ b/terraform/staging-paas/terraform.tfvars
@@ -1,0 +1,16 @@
+publicapi_credentials = {
+  pay_low_pass_secrets = {
+    sentry_dsn = "sentry/publicapi_dsn"
+  }
+  static_values = {
+    rate_limiter_value = "200"
+    rate_limiter_value_post = "100"
+    redis_url = "none"
+    rate_limiter_reqs_node = "200"
+    rate_limiter_reqs_node_post = "100"
+    rate_limiter_elevated_accounts = "31"
+    rate_limiter_elevated_value_get = "100"
+    rate_limiter_elevated_value_post = "200"
+    token_api_hmac_secret = "something"
+  }
+}

--- a/terraform/staging-paas/variables.tf
+++ b/terraform/staging-paas/variables.tf
@@ -1,0 +1,3 @@
+variable "publicapi_credentials" {
+  type = map(map(string))
+}


### PR DESCRIPTION
Implement version 1 of provisioning secrets in paas. It is likely that
this will be replaced when PaaS provide a more robust means for secrets
management.

This adds a credentials module which will gather secrets from
pay-low-pass. The credentials are set on a user provided service which
will be bound to the app.

To get it started this commit deals with publicapi but the same approach
and be used for the other apps.

with @rjbaker

## WHAT
We intend to iterate and improve upon this but this is a start. Comments and feedback welcomed to help us improve this as we roll it out for the other apps.