### PR TITLE
PP-6127 Restructure credentials variable and add connector

### DIFF
--- a/terraform/modules/paas/card-connector.tf
+++ b/terraform/modules/paas/card-connector.tf
@@ -1,3 +1,7 @@
+locals {
+  card_connector_credentials = lookup(var.credentials, "card_connector")
+}
+
 resource "cloudfoundry_app" "card_connector" {
   name    = "card-connector"
   space   = data.cloudfoundry_space.cde_space.id
@@ -16,4 +20,15 @@ resource "cloudfoundry_route" "card_connector" {
   target {
     app = cloudfoundry_app.card_connector.id
   }
+}
+
+module "card_connector_credentials" {
+  source = "../credentials"
+  pay_low_pass_secrets = lookup(local.card_connector_credentials, "pay_low_pass_secrets")
+}
+
+resource "cloudfoundry_user_provided_service" "card_connector_secret_service" {
+  name        = "card-connector-secret-service"
+  space       = data.cloudfoundry_space.space.id
+  credentials = merge(module.card_connector_credentials.secrets, lookup(local.card_connector_credentials, "static_values"))
 }

--- a/terraform/modules/paas/card-connector.tf
+++ b/terraform/modules/paas/card-connector.tf
@@ -29,6 +29,6 @@ module "card_connector_credentials" {
 
 resource "cloudfoundry_user_provided_service" "card_connector_secret_service" {
   name        = "card-connector-secret-service"
-  space       = data.cloudfoundry_space.space.id
+  space       = data.cloudfoundry_space.cde_space.id
   credentials = merge(module.card_connector_credentials.secrets, lookup(local.card_connector_credentials, "static_values"))
 }

--- a/terraform/modules/paas/publicapi.tf
+++ b/terraform/modules/paas/publicapi.tf
@@ -1,3 +1,7 @@
+locals {
+  publicapi_credentials = lookup(var.credentials, "publicapi")
+}
+
 resource "cloudfoundry_app" "publicapi" {
   name    = "publicapi"
   space   = data.cloudfoundry_space.space.id
@@ -38,11 +42,11 @@ resource "cloudfoundry_network_policy" "publicapi" {
 
 module "publicapi_credentials" {
   source = "../credentials"
-  pay_low_pass_secrets = lookup(var.publicapi_credentials, "pay_low_pass_secrets")
+  pay_low_pass_secrets = lookup(local.publicapi_credentials, "pay_low_pass_secrets")
 }
 
 resource "cloudfoundry_user_provided_service" "publicapi_secret_service" {
   name        = "publicapi-secret-service"
   space       = data.cloudfoundry_space.space.id
-  credentials = merge(module.publicapi_credentials.secrets, lookup(var.publicapi_credentials, "static_values"))
+  credentials = merge(module.publicapi_credentials.secrets, lookup(local.publicapi_credentials, "static_values"))
 }

--- a/terraform/modules/paas/variables.tf
+++ b/terraform/modules/paas/variables.tf
@@ -25,7 +25,7 @@ variable "external_hostname_suffix" {
   default     = ""
 }
 
-variable "publicapi_credentials" {
-  type        = map(map(string))
-  description = "credential for publicapi"
+variable "credentials" {
+  type        = map(map(map(string)))
+  description = "credential for the apps"
 }

--- a/terraform/staging-paas/site.tf
+++ b/terraform/staging-paas/site.tf
@@ -25,7 +25,7 @@ module "paas" {
   external_domain          = "staging.gdspay.uk"
   external_hostname_suffix = ""
   internal_hostname_suffix = "-stg"
-  publicapi_credentials    = var.publicapi_credentials
+  credentials    = var.credentials
 }
 
 module "paas_postgres" {

--- a/terraform/staging-paas/terraform.tfvars
+++ b/terraform/staging-paas/terraform.tfvars
@@ -1,16 +1,24 @@
-publicapi_credentials = {
-  pay_low_pass_secrets = {
-    sentry_dsn = "sentry/publicapi_dsn"
+credentials = {
+  publicapi = {
+    pay_low_pass_secrets = {
+      sentry_dsn = "sentry/publicapi_dsn"
+    }
+    static_values = {
+      rate_limiter_value = "200"
+      rate_limiter_value_post = "100"
+      redis_url = "none"
+      rate_limiter_reqs_node = "200"
+      rate_limiter_reqs_node_post = "100"
+      rate_limiter_elevated_accounts = "31"
+      rate_limiter_elevated_value_get = "100"
+      rate_limiter_elevated_value_post = "200"
+      token_api_hmac_secret = "something"
+    }
   }
-  static_values = {
-    rate_limiter_value = "200"
-    rate_limiter_value_post = "100"
-    redis_url = "none"
-    rate_limiter_reqs_node = "200"
-    rate_limiter_reqs_node_post = "100"
-    rate_limiter_elevated_accounts = "31"
-    rate_limiter_elevated_value_get = "100"
-    rate_limiter_elevated_value_post = "200"
-    token_api_hmac_secret = "something"
+  card_connector = {
+    pay_low_pass_secrets = {
+    }
+    static_values = {
+    }
   }
 }

--- a/terraform/staging-paas/terraform.tfvars
+++ b/terraform/staging-paas/terraform.tfvars
@@ -17,8 +17,28 @@ credentials = {
   }
   card_connector = {
     pay_low_pass_secrets = {
+      #aws_access_key = "not sure what these are"
+      #aws_secret_key = "not sure what these are"
+      apple_pay_certificate = "apple_pay/staging/payment-processing-certificate"
+      apple_pay_key = "apple_pay/staging/payment-processing-private-key"
+      smartpay_notification_password = "smartpay/notifications/dcotest/password"
+      smartpay_notification_user = "smartpay/notifications/dcotest/username"
+      notify_api_key = "notify/api_key/staging"
     }
     static_values = {
+      secure_worldpay_notification_domain = "london.cloudapps.digital"
+      secure_worldpay_notification_enabled = "false"
+      worldpay_live_url = "https://example.com/stub/worldpay"
+      worldpay_test_url = "https://example.com/stub/worldpay"
+      smartpay_test_url = "https://example.com/stub/smartpay"
+      smartpay_live_url = "https://example.com/stub/smartpay"
+      epdq_live_url = "https://example.com/stub/epdq"
+      epdq_test_url = "https://example.com/stub/epdq"
+      sqs_enabled = "false"
+      notify_base_url = "https://example.com/notify"
+      notify_receipt_email_template_id = "email-template-id"
+      notify_refund_email_template_id = "email-refund-issued-template-id"
+      stripe_transaction_fee_percentage = "0.1"
     }
   }
 }

--- a/terraform/staging-paas/variables.tf
+++ b/terraform/staging-paas/variables.tf
@@ -1,3 +1,3 @@
-variable "publicapi_credentials" {
-  type = map(map(string))
+variable "credentials" {
+  type = map(map(map(string)))
 }


### PR DESCRIPTION
    Make the credentials variable a map of apps and their credentials
    (previously it was only for publicapi). This allows us to add apps
    without having to modify how we pass the values into the paas module.

    Second commit adds the creds for connector.

## HOW WHAT WHY
I've tested this in staging by running the terraform and binding card-connector, it then has the necessary vars within VCAP-Services. 
