### PR TITLE
PP-6132: Database migration pipeline

### DIFF
--- a/ci/pipelines/deploy.yml
+++ b/ci/pipelines/deploy.yml
@@ -667,5 +667,11 @@ jobs:
                   -o "$CF_ORG" -s "$CF_SPACE"
                 cf run-task ${APP_NAME} '/home/vcap/app/.java-buildpack/open_jdk_jre/bin/java -Djava.security.properties=/home/vcap/app/.java-buildpack/java_security/java.security -Xms512m -Xmx1G -cp /home/vcap/app/.:/home/vcap/app/.java-buildpack/client_certificate_mapper/client_certificate_mapper-1.11.0_RELEASE.jar:/home/vcap/app/.java-buildpack/postgresql_jdbc/postgresql_jdbc-42.2.9.jar:/home/vcap/app/.java-buildpack/container_security_provider/container_security_provider-1.16.0_RELEASE.jar uk.gov.pay.products.ProductsApplication db migrate /home/vcap/app/config/config.yaml' --name "${APP_NAME}-db-migration"
                 echo "Fetching task logs:"
-                cf logs ${APP_NAME} | grep -F '[APP/TASK/' > migration.log &
-                ( tail -f migration.log & ) | sed '/Exit status/q'
+                cf logs ${APP_NAME} | sed '/Exit status/q' > migration.log
+                EXIT_CODE=$(cat migration.log | sed -En 's/.*Exit status ([0-9]*)/\1/p')
+                cat migration.log | awk '$3 ~ /(\[APP\/TASK\/)*/' | grep -o '{.*}' | jq '.message' -r
+                if [ $EXIT_CODE != 0 ]
+                then
+                  exit 1
+                fi
+                

--- a/ci/pipelines/deploy.yml
+++ b/ci/pipelines/deploy.yml
@@ -52,6 +52,10 @@ groups:
       - direct-debit-smoke-tests-staging
       - products-smoke-test-staging
 
+  - name: Staging DB Migrations
+    jobs:
+      - migrate-products-db-staging
+
 resource_types:
   - name: cf-cli
     type: docker-image
@@ -635,3 +639,33 @@ jobs:
         params:
           <<: *smoke-test-params
           COMMAND: cf ssh smoke-tests-staging -c /app/bin/smoke-products
+
+  - name: migrate-products-db-staging
+    plan:
+      - get: omnibus
+      - task: run-migration
+        params:
+          <<: *cf-creds
+          CF_SPACE: staging
+          CF_SPACE_CDE: staging-cde
+          APP_NAME: products
+          APP_PACKAGE: uk.gov.pay.products.ProductsApplication
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/cf-cli 
+          run:
+            path: bash
+            args:
+              - -c
+              - |
+                set -o errexit -o nounset
+                cf login -a "$CF_API" \
+                  -u "$CF_USERNAME" -p "$CF_PASSWORD" \
+                  -o "$CF_ORG" -s "$CF_SPACE"
+                cf run-task ${APP_NAME} '/home/vcap/app/.java-buildpack/open_jdk_jre/bin/java -Djava.security.properties=/home/vcap/app/.java-buildpack/java_security/java.security -Xms512m -Xmx1G -cp /home/vcap/app/.:/home/vcap/app/.java-buildpack/client_certificate_mapper/client_certificate_mapper-1.11.0_RELEASE.jar:/home/vcap/app/.java-buildpack/postgresql_jdbc/postgresql_jdbc-42.2.9.jar:/home/vcap/app/.java-buildpack/container_security_provider/container_security_provider-1.16.0_RELEASE.jar uk.gov.pay.products.ProductsApplication db migrate /home/vcap/app/config/config.yaml' --name "${APP_NAME}-db-migration"
+                echo "Fetching task logs:"
+                cf logs ${APP_NAME} | grep -F '[APP/TASK/' > migration.log &
+                ( tail -f migration.log & ) | sed '/Exit status/q'

--- a/ci/pipelines/deploy.yml
+++ b/ci/pipelines/deploy.yml
@@ -22,6 +22,12 @@ groups:
       - card-payment-smoke-tests-staging
       - direct-debit-smoke-tests-staging
       - products-smoke-test-staging
+      - migrate-adminusers-db-staging
+      - migrate-card-connector-db-staging
+      - migrate-directdebit-connector-db-staging
+      - migrate-ledger-db-staging
+      - migrate-products-db-staging
+      - migrate-publicauth-db-staging
 
   - name: Staging Deploys
     jobs:
@@ -41,6 +47,12 @@ groups:
       - deploy-notifications-staging
       - deploy-toolbox-staging
       - deploy-sqs-staging
+      - migrate-adminusers-db-staging
+      - migrate-card-connector-db-staging
+      - migrate-directdebit-connector-db-staging
+      - migrate-ledger-db-staging
+      - migrate-products-db-staging
+      - migrate-publicauth-db-staging
 
   - name: Smoke Tests
     jobs:
@@ -648,6 +660,7 @@ jobs:
   - name: migrate-adminusers-db-staging
     plan:
       - get: omnibus
+      - get: git-adminusers-pre-release
         passed: [deploy-adminusers-staging]
         trigger: true
       - &run-migration
@@ -664,6 +677,7 @@ jobs:
   - name: migrate-card-connector-db-staging
     plan:
       - get: omnibus
+      - get: git-card-connector-pre-release
         passed: [deploy-card-connector-staging]
         trigger: true
       - <<: *run-migration
@@ -677,6 +691,7 @@ jobs:
   - name: migrate-directdebit-connector-db-staging
     plan:
       - get: omnibus
+      - get: git-directdebit-connector-pre-release
         passed: [deploy-directdebit-connector-staging]
         trigger: true
       - <<: *run-migration
@@ -690,6 +705,7 @@ jobs:
   - name: migrate-ledger-db-staging
     plan:
       - get: omnibus
+      - get: git-ledger-pre-release
         passed: [deploy-ledger-staging]
         trigger: true
       - <<: *run-migration
@@ -703,6 +719,7 @@ jobs:
   - name: migrate-products-db-staging
     plan:
       - get: omnibus
+      - get: git-products-pre-release
         passed: [deploy-products-staging]
         trigger: true
       - <<: *run-migration
@@ -716,6 +733,7 @@ jobs:
   - name: migrate-publicauth-db-staging
     plan:
       - get: omnibus
+      - get: git-publicauth-pre-release
         passed: [deploy-publicauth-staging]
         trigger: true
       - <<: *run-migration

--- a/ci/pipelines/deploy.yml
+++ b/ci/pipelines/deploy.yml
@@ -54,7 +54,12 @@ groups:
 
   - name: Staging DB Migrations
     jobs:
+      - migrate-adminusers-db-staging
+      - migrate-card-connector-db-staging
+      - migrate-directdebit-connector-db-staging
+      - migrate-ledger-db-staging
       - migrate-products-db-staging
+      - migrate-publicauth-db-staging
 
 resource_types:
   - name: cf-cli
@@ -640,39 +645,84 @@ jobs:
           <<: *smoke-test-params
           COMMAND: cf ssh smoke-tests-staging -c /app/bin/smoke-products
 
-  - name: migrate-products-db-staging
+  - name: migrate-adminusers-db-staging
     plan:
       - get: omnibus
-      - task: run-migration
+        passed: [deploy-adminusers-staging]
+        trigger: true
+      - &run-migration
+        task: run-migration
+        file: omnibus/ci/tasks/cf-task.yml
+        input_mapping: { workdir: omnibus }
         params:
           <<: *cf-creds
           CF_SPACE: staging
-          CF_SPACE_CDE: staging-cde
+          COMMAND: workdir/ci/scripts/migrate_database.sh
+          APP_NAME: adminusers
+          APP_PACKAGE: uk.gov.pay.adminusers.app.AdminUsersApp
+    
+  - name: migrate-card-connector-db-staging
+    plan:
+      - get: omnibus
+        passed: [deploy-card-connector-staging]
+        trigger: true
+      - <<: *run-migration
+        params:
+          <<: *cf-creds
+          CF_SPACE: staging-cde
+          COMMAND: workdir/ci/scripts/migrate_database.sh
+          APP_NAME: card-connector
+          APP_PACKAGE: uk.gov.pay.connector.app.ConnectorApp
+
+  - name: migrate-directdebit-connector-db-staging
+    plan:
+      - get: omnibus
+        passed: [deploy-directdebit-connector-staging]
+        trigger: true
+      - <<: *run-migration
+        params:
+          <<: *cf-creds
+          CF_SPACE: staging
+          COMMAND: workdir/ci/scripts/migrate_database.sh
+          APP_NAME: directdebit-connector
+          APP_PACKAGE: uk.gov.pay.directdebit.DirectDebitConnectorApp
+
+  - name: migrate-ledger-db-staging
+    plan:
+      - get: omnibus
+        passed: [deploy-ledger-staging]
+        trigger: true
+      - <<: *run-migration
+        params:
+          <<: *cf-creds
+          CF_SPACE: staging
+          COMMAND: workdir/ci/scripts/migrate_database.sh
+          APP_NAME: ledger
+          APP_PACKAGE: uk.gov.pay.ledger.LedgerApp
+  
+  - name: migrate-products-db-staging
+    plan:
+      - get: omnibus
+        passed: [deploy-products-staging]
+        trigger: true
+      - <<: *run-migration
+        params:
+          <<: *cf-creds
+          CF_SPACE: staging
+          COMMAND: workdir/ci/scripts/migrate_database.sh
           APP_NAME: products
           APP_PACKAGE: uk.gov.pay.products.ProductsApplication
-        config:
-          platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: governmentpaas/cf-cli 
-          run:
-            path: bash
-            args:
-              - -c
-              - |
-                set -o errexit -o nounset
-                cf login -a "$CF_API" \
-                  -u "$CF_USERNAME" -p "$CF_PASSWORD" \
-                  -o "$CF_ORG" -s "$CF_SPACE"
-                cf run-task ${APP_NAME} '/home/vcap/app/.java-buildpack/open_jdk_jre/bin/java -Djava.security.properties=/home/vcap/app/.java-buildpack/java_security/java.security -Xms512m -Xmx1G -cp /home/vcap/app/.:/home/vcap/app/.java-buildpack/client_certificate_mapper/client_certificate_mapper-1.11.0_RELEASE.jar:/home/vcap/app/.java-buildpack/postgresql_jdbc/postgresql_jdbc-42.2.9.jar:/home/vcap/app/.java-buildpack/container_security_provider/container_security_provider-1.16.0_RELEASE.jar uk.gov.pay.products.ProductsApplication db migrate /home/vcap/app/config/config.yaml' --name "${APP_NAME}-db-migration"
-                echo "You can view the raw logs using: cf logs ${APP_NAME} --recent"
-                echo "Fetching task logs:"
-                cf logs ${APP_NAME} | sed '/Exit status/q' > migration.log
-                EXIT_CODE=$(cat migration.log | sed -En 's/.*Exit status ([0-9]*)/\1/p')
-                cat migration.log | awk '$4 ~ /(\[APP\/TASK\/)*/' | grep -o '{.*}' | jq '.message' -r
-                if [ $EXIT_CODE != 0 ]
-                then
-                  exit 1
-                fi
+
+  - name: migrate-publicauth-db-staging
+    plan:
+      - get: omnibus
+        passed: [deploy-publicauth-staging]
+        trigger: true
+      - <<: *run-migration
+        params:
+          <<: *cf-creds
+          CF_SPACE: staging
+          COMMAND: workdir/ci/scripts/migrate_database.sh
+          APP_NAME: publicauth
+          APP_PACKAGE: uk.gov.pay.publicauth.app.PublicAuthApp
                 

--- a/ci/pipelines/deploy.yml
+++ b/ci/pipelines/deploy.yml
@@ -666,10 +666,11 @@ jobs:
                   -u "$CF_USERNAME" -p "$CF_PASSWORD" \
                   -o "$CF_ORG" -s "$CF_SPACE"
                 cf run-task ${APP_NAME} '/home/vcap/app/.java-buildpack/open_jdk_jre/bin/java -Djava.security.properties=/home/vcap/app/.java-buildpack/java_security/java.security -Xms512m -Xmx1G -cp /home/vcap/app/.:/home/vcap/app/.java-buildpack/client_certificate_mapper/client_certificate_mapper-1.11.0_RELEASE.jar:/home/vcap/app/.java-buildpack/postgresql_jdbc/postgresql_jdbc-42.2.9.jar:/home/vcap/app/.java-buildpack/container_security_provider/container_security_provider-1.16.0_RELEASE.jar uk.gov.pay.products.ProductsApplication db migrate /home/vcap/app/config/config.yaml' --name "${APP_NAME}-db-migration"
+                echo "You can view the raw logs using: cf logs ${APP_NAME} --recent"
                 echo "Fetching task logs:"
                 cf logs ${APP_NAME} | sed '/Exit status/q' > migration.log
                 EXIT_CODE=$(cat migration.log | sed -En 's/.*Exit status ([0-9]*)/\1/p')
-                cat migration.log | awk '$3 ~ /(\[APP\/TASK\/)*/' | grep -o '{.*}' | jq '.message' -r
+                cat migration.log | awk '$4 ~ /(\[APP\/TASK\/)*/' | grep -o '{.*}' | jq '.message' -r
                 if [ $EXIT_CODE != 0 ]
                 then
                   exit 1

--- a/ci/scripts/migrate-database.sh
+++ b/ci/scripts/migrate-database.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-set -eu
-
-#cat migration_output.txt | \
-#  awk '$2 ~ /(\[APP\/TASK\/)*/' | \
-#  grep -o '{.*}' | jq '.message' -r

--- a/ci/scripts/migrate-database.sh
+++ b/ci/scripts/migrate-database.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -eu
+
+#cat migration_output.txt | \
+#  awk '$2 ~ /(\[APP\/TASK\/)*/' | \
+#  grep -o '{.*}' | jq '.message' -r

--- a/ci/scripts/migrate_database.sh
+++ b/ci/scripts/migrate_database.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -o errexit -o nounset
+
+: ${APP_NAME:?APP_NAME is required (e.g. card-connector)}
+: ${APP_PACKAGE:?APP_PACKAGE is required (e.g. uk.gov.pay.connector.ConnectorApplication)}
+
+TASK_COMMAND="/home/vcap/app/.java-buildpack/open_jdk_jre/bin/java \
+-Djava.security.properties=/home/vcap/app/.java-buildpack/java_security/java.security -Xms512m -Xmx1G \
+-cp /home/vcap/app/.:/home/vcap/app/.java-buildpack/client_certificate_mapper/client_certificate_mapper-1.11.0_RELEASE.jar:\
+/home/vcap/app/.java-buildpack/postgresql_jdbc/postgresql_jdbc-42.2.9.jar:\
+/home/vcap/app/.java-buildpack/container_security_provider/container_security_provider-1.16.0_RELEASE.jar \
+${APP_PACKAGE} db migrate /home/vcap/app/config/config.yaml"
+
+cf run-task ${APP_NAME} "${TASK_COMMAND}" --name "${APP_NAME}-db-migration"
+
+echo "You can view the raw logs using: cf logs ${APP_NAME} --recent"
+echo "Fetching task logs:"
+
+cf logs ${APP_NAME} | sed '/Exit status/q' > migration.log
+
+EXIT_CODE=$(cat migration.log | sed -En 's/.*Exit status ([0-9]*)/\1/p')
+
+cat migration.log | awk '$4 ~ /(\[APP\/TASK\/)*/' | grep -o '{.*}' | jq '.message' -r
+
+if [ $EXIT_CODE != 0 ]
+then
+  cat migration.log
+  exit 1
+fi


### PR DESCRIPTION
Adds database migration pipelines triggered by deployment jobs.

 - Executes a bash script inside the cf-task container, targeting the relevant space and app.
 - Runs the Java migration task via `cf run task ...`
 - Retrieves logs for the task whilst running via `cf logs ...`
 - Parses log lines related to the running task
 - Parses JSON log lines into plain text
 - Parses the task exit code to determine the job result

Todo: 
- [ ] shellcheck
- [ ] glob java module paths

![Screenshot 2020-02-18 at 14 09 58](https://user-images.githubusercontent.com/783245/74743506-6ac33880-5258-11ea-81f5-22ca95712845.png)
