### PR TITLE
Add new OAuth creds for toolbox in paas staging

### DIFF
--- a/terraform/staging-paas/terraform.tfvars
+++ b/terraform/staging-paas/terraform.tfvars
@@ -74,8 +74,8 @@ credentials = {
   }
   toolbox = {
     pay_low_pass_secrets = {
-      auth_github_client_id = "pay-toolbox/staging/github_client_id"
-      auth_github_client_secret = "pay-toolbox/staging/github_client_secret"
+      auth_github_client_id = "pay-toolbox/paas_staging/github_client_id"
+      auth_github_client_secret = "pay-toolbox/paas_staging/github_client_secret"
       stripe_account_api_key = "stripe/staging/test/account-api-key"
       sentry_dsn = "sentry/toolbox_dsn"
     }


### PR DESCRIPTION
We cannot reuse the existing staging creds as github redirects to the
associated redirect url for those credentials. This uses new creds added
to pay-low-pass for our paas staging space.

Linked to PR https://github.com/alphagov/pay-low-pass/pull/152