### PR TITLE
PP-6147: Decrypt field level encryption fields

### DIFF
--- a/ci/pipelines/build.yml
+++ b/ci/pipelines/build.yml
@@ -98,18 +98,20 @@ resources:
 
   # Source Code Resources
   - &git-repo
-    name: card-frontend-source
+    name: toolbox-source
     type: git
     icon: github-circle
     source: &git-repo-source
-      uri: https://github.com/alphagov/pay-frontend
+      uri: https://github.com/alphagov/pay-toolbox
       branch: master
 
   - <<: *git-repo
-    name: toolbox-source
+    name: card-frontend-source
     source:
       <<: *git-repo-source
-      uri: https://github.com/alphagov/pay-toolbox
+      uri: https://github.com/alphagov/pay-frontend
+      # TODO: remove this once https://github.com/alphagov/pay-frontend/pull/1388 is merged
+      branch: PP-6147-decrypt-field-level-encryption-fields
 
   - <<: *git-repo
     name: products-ui-source

--- a/terraform/modules/aws/card-frontend.tf
+++ b/terraform/modules/aws/card-frontend.tf
@@ -36,7 +36,7 @@ resource "aws_cloudfront_distribution" "card_frontend" {
     max_ttl                = 0
     default_ttl            = 0
 
-    #field_level_encryption_id = data.external.card_frontend_fle_config.result["id"]
+    field_level_encryption_id = data.external.card_frontend_fle_config.result["id"]
 
     forwarded_values {
       headers      = ["Host", "Origin", "Authorization"]

--- a/terraform/modules/aws/provision_fle_config.rb
+++ b/terraform/modules/aws/provision_fle_config.rb
@@ -54,7 +54,7 @@ CONFIG_JSON = <<EOS
         }
     },
     "ContentTypeProfileConfig": {
-        "ForwardWhenContentTypeIsUnknown": false,
+        "ForwardWhenContentTypeIsUnknown": true,
         "ContentTypeProfiles": {
             "Quantity": 1,
             "Items": [

--- a/terraform/modules/aws/provision_fle_config.rb
+++ b/terraform/modules/aws/provision_fle_config.rb
@@ -32,7 +32,6 @@ PROFILE_JSON = <<EOS
                     "Items": [
                         "cvc",
                         "cardNo",
-                        "addressPostcode",
                         "expiryYear",
                         "expiryMonth"
                     ]

--- a/terraform/modules/aws/provision_fle_config.rb
+++ b/terraform/modules/aws/provision_fle_config.rb
@@ -28,7 +28,7 @@ PROFILE_JSON = <<EOS
                 "PublicKeyId": "",
                 "ProviderId": "frontend",
                 "FieldPatterns": {
-                    "Quantity": 5,
+                    "Quantity": 4,
                     "Items": [
                         "cvc",
                         "cardNo",

--- a/terraform/modules/credentials/main.tf
+++ b/terraform/modules/credentials/main.tf
@@ -2,8 +2,8 @@ locals {
   /* This needs some careful checking. If keys() and values() do not 
   return the corresponding hash keys and values in the same order then the
   zipped result will have the wrong value for a key. Perhaps there's a better way*/
-  low_pass_values = zipmap(keys(data.pass_password.secret), values(data.pass_password.secret).*.password)
-  dev_pass_values = zipmap(keys(data.pass_password.dev_secret), values(data.pass_password.dev_secret).*.password)
+  low_pass_values = zipmap(keys(data.pass_password.secret), values(data.pass_password.secret).*.full)
+  dev_pass_values = zipmap(keys(data.pass_password.dev_secret), values(data.pass_password.dev_secret).*.full)
 }
 
 provider "pass" {

--- a/terraform/staging-paas/terraform.tfvars
+++ b/terraform/staging-paas/terraform.tfvars
@@ -65,6 +65,8 @@ credentials = {
   }
   card_frontend = {
     pay_low_pass_secrets = {
+      // @todo make this a real thing in pay-low-pass
+      field_level_encryption_private_key = "field_level_encryption_key/staging/frontend"
     }
     static_values = {
       // @todo add this placeholder to secrets

--- a/terraform/staging-paas/terraform.tfvars
+++ b/terraform/staging-paas/terraform.tfvars
@@ -72,6 +72,8 @@ credentials = {
       // @todo add this placeholder to secrets
       card_frontend_session_encryption_key = "asdjhbwefbo23r23rbfik2roiwhefwbqw"
       card_frontend_analytics_tracking_id = "testing-123"
+      field_level_encryption_key_name = "staging-card-frontend-fle-pubkey"
+      field_level_encryption_key_namespace = "frontend"
     }
   }
   toolbox = {


### PR DESCRIPTION
- Enables FLE on the card-frontend Cloudfront distribution.
- Adds necessary FLE keys to secrets and application configuration
- Enable request forwarding when a non form-encoded data (json) is used

See card-frontend changes in: alphagov/pay-frontend#1388