### PR TITLE
PP-6146: Ensure Notifications app is pushed as a Docker app

### DIFF
--- a/terraform/modules/paas/notifications.tf
+++ b/terraform/modules/paas/notifications.tf
@@ -1,10 +1,11 @@
 resource "cloudfoundry_app" "notifications" {
-  name    = "notifications"
-  space   = data.cloudfoundry_space.space.id
-  stopped = true
+  name         = "notifications"
+  space        = data.cloudfoundry_space.space.id
+  stopped      = true
+  docker_image = "alpine:latest"
 
   lifecycle {
-    ignore_changes = [stopped, health_check_type]
+    ignore_changes = [stopped, health_check_type, docker_image]
   }
 }
 


### PR DESCRIPTION
This was being created as a buildpack-based app, which causes initial deployment of the Docker container to fail because app types can not be changed once pushed.

Since the notifications app container is specified using an app manifest applied via Concourse, the initial Terraform run will create an empty docker app and ignore the image in subsequent runs.