### PR TITLE
PP-6146: Check for existing smoke-test user before creating

### DIFF
--- a/client/client
+++ b/client/client
@@ -45,6 +45,7 @@ class AppClient
     service_id = service.fetch('external_id')
 
     STDERR.puts '🤓  Creating admin user for service'
+    user_name += SecureRandom.hex
     user = create_user(username: user_name, gateway_account_ids: gateway_account_ids)
     STDERR.puts '😎  Creating read only user for service'
     create_user(gateway_account_ids: gateway_account_ids, role_name: 'view-only')


### PR DESCRIPTION
In scenarios where a smoke test user already exists, attach the user to the new service and return existing credentials.