### PR TITLE
Remove node_modules directory before installing prod dependencies

### DIFF
--- a/ci/tasks/node-build.yml
+++ b/ci/tasks/node-build.yml
@@ -33,6 +33,7 @@ run:
       npm rebuild node-sass
       npm install
       npm run compile
+      rm -rf ./node_modules
       npm install --only=prod
 
       release_number="$(cat ../release-info/number)"


### PR DESCRIPTION
Explicitly remove all dev dependencies in node_modules before reinstalling production dependencies only. Previously this incorrectly assumed `--only=prod` pruned dev dependencies.