### PR TITLE
Fix node_module cache behaviour when removing dev dependencies

### DIFF
--- a/ci/tasks/node-build.yml
+++ b/ci/tasks/node-build.yml
@@ -14,7 +14,8 @@ outputs:
   - name: build-output
 
 caches:
-  - path: src/node_modules
+  - path: node_module_cache_dev
+  - path: node_module_cache_prod
 
 params:
   LD_LIBRARY_PATH: /src/node_modules/appmetrics
@@ -30,14 +31,16 @@ run:
       node --version
       npm --version
       apk add --virtual build-dependencies --update python build-base libexecinfo-dev
+      ln -s ../node_module_cache_dev node_modules
       npm rebuild node-sass
       npm install
       npm run compile
-      rm -rf ./node_modules
+      rm node_modules
+      ln -s ../node_module_cache_prod node_modules
       npm install --only=prod
 
       release_number="$(cat ../release-info/number)"
       archive_path="../build-output/${APP_NAME}-${release_number}.tar.gz"
 
       echo "Creating build archive in: ${archive_path}"
-      tar -czf "$archive_path" --exclude .git .
+      tar -czfh "$archive_path" --exclude .git .

--- a/ci/tasks/node-build.yml
+++ b/ci/tasks/node-build.yml
@@ -14,7 +14,7 @@ outputs:
   - name: build-output
 
 caches:
-  - path: ../../../root/.npm
+  - path: npm_cache
 
 params:
   LD_LIBRARY_PATH: /src/node_modules/appmetrics
@@ -30,6 +30,7 @@ run:
       node --version
       npm --version
       apk add --virtual build-dependencies --update python build-base libexecinfo-dev
+      npm config set cache ../npm_cache
       npm rebuild node-sass
       npm install
       npm run compile

--- a/ci/tasks/node-build.yml
+++ b/ci/tasks/node-build.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: node
-    tag: 12.11.1-alpine
+    tag: 12.14-alpine
 
 inputs:
   - name: src

--- a/ci/tasks/node-build.yml
+++ b/ci/tasks/node-build.yml
@@ -14,8 +14,7 @@ outputs:
   - name: build-output
 
 caches:
-  - path: node_module_cache_dev
-  - path: node_module_cache_prod
+  - path: ../../../root/.npm
 
 params:
   LD_LIBRARY_PATH: /src/node_modules/appmetrics
@@ -31,16 +30,14 @@ run:
       node --version
       npm --version
       apk add --virtual build-dependencies --update python build-base libexecinfo-dev
-      ln -s ../node_module_cache_dev node_modules
       npm rebuild node-sass
       npm install
       npm run compile
-      rm node_modules
-      ln -s ../node_module_cache_prod node_modules
+      rm -rf node_modules
       npm install --only=prod
 
       release_number="$(cat ../release-info/number)"
       archive_path="../build-output/${APP_NAME}-${release_number}.tar.gz"
 
       echo "Creating build archive in: ${archive_path}"
-      tar -czfh "$archive_path" --exclude .git .
+      tar -czf "$archive_path" --exclude .git .


### PR DESCRIPTION
Caches ~/.npm global directory reducing the number of packages that are re-downloaded between dev and prod dependency installs. Props to @danworth 👍 