### PR TITLE
Don't abort create user if app isn't up

### DIFF
--- a/client/client
+++ b/client/client
@@ -301,7 +301,7 @@ def forward_app(app, port)
     tries += 1
     sleep(1)
   end
-  abort("#{app}[#{port}]: timed out")
+  STDERR.puts("#{app}[#{port}]: not up")
 end
 
 STDERR.puts("Forwarding apps:")


### PR DESCRIPTION
Not all apps might be up, e.g. directdebit-connector so if they are
not available after retrying when attempting to forward ports, just
log and continue. The script handles apps not being up later on.