### PR TITLE
PP-6245 Carbon-relay and stunnel in apt buildback

### DIFF
--- a/paas/carbon-relay/apt.yml
+++ b/paas/carbon-relay/apt.yml
@@ -1,0 +1,9 @@
+---
+keys:
+  - https://packagecloud.io/raintank/raintank/gpgkey
+repos:
+  - deb https://packagecloud.io/raintank/raintank/ubuntu/ xenial main
+  - deb-src https://packagecloud.io/raintank/raintank/ubuntu/ xenial main
+packages:
+  - carbon-relay-ng
+  - stunnel

--- a/paas/carbon-relay/carbon-relay-ng.ini.erb
+++ b/paas/carbon-relay/carbon-relay-ng.ini.erb
@@ -1,0 +1,48 @@
+instance = "default"
+
+max_procs = 2
+
+listen_addr = "0.0.0.0:2003"
+
+admin_addr = "0.0.0.0:2004"
+
+http_addr = "0.0.0.0:8081"
+
+# Metric name validation strictness for legacy metrics. Valid values are:
+# strict - Block anything that can upset graphite: valid characters are [A-Za-z0-9_-.]; consecutive dots are not allowed
+# medium - Valid characters are ASCII; no embedded NULLs
+# none   - No validation is performed
+validation_level_legacy = "medium"
+
+# Metric validation for carbon2.0 (metrics2.0) metrics.
+# Metrics that contain = or _is_ are assumed carbon2.0.
+# Valid values are:
+# medium - checks for unit and mtype tag, presence of another tag, and constency (use = or _is_, not both)
+# none   - No validation is performed
+validation_level_m20 = "none"
+
+log_level = "warning"
+bad_metrics_max_age = "24h"
+spool_dir = "/var/spool/carbon-relay-ng"
+blacklist = [
+  'prefix carbon-relay-ng',
+  'prefix service_is_carbon-relay-ng'
+]
+
+[[route]]
+key = 'carbon-default'
+type = 'sendAllMatch'
+destinations = [
+  '127.0.0.1:20030'
+]
+
+[[rewriter]]
+old = '/^/'
+new = '<%= ENV.fetch('HOSTED_GRAPHITE_API_KEY') %>.'
+not = ''
+max = -1
+
+[instrumentation]
+graphite_addr = "localhost:2003"
+graphite_interval = 1000
+

--- a/paas/carbon-relay/manifest.yml
+++ b/paas/carbon-relay/manifest.yml
@@ -1,0 +1,11 @@
+---
+applications:
+  - name: carbon-relay
+    health-check-type: process
+    buildpacks:
+    - https://github.com/cloudfoundry/apt-buildpack
+    - https://github.com/cloudfoundry/binary-buildpack
+    command: ./start.sh
+    env:
+      HOSTED_GRAPHITE_HOST: ((hosted_graphite_host))
+      HOSTED_GRAPHITE_API_KEY: ((hosted_graphite_api_key))

--- a/paas/carbon-relay/start.sh
+++ b/paas/carbon-relay/start.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -o errexit -o nounset -o pipefail
+
+erb stunnel.conf.erb > stunnel.conf
+erb carbon-relay-ng.ini.erb > carbon-relay-ng.ini
+
+stunnel stunnel.conf hosted_graphite &
+carbon-relay-ng carbon-relay-ng.ini
+

--- a/paas/carbon-relay/stunnel.conf.erb
+++ b/paas/carbon-relay/stunnel.conf.erb
@@ -1,0 +1,18 @@
+; Disable support for old TLS protocols
+options = NO_SSLv3
+options = NO_TLSv1
+;options = NO_TLSv1.1
+;options = NO_TLSv1.2
+;options = NO_TLSv1_3
+
+pid = /home/vcap/app/stunnel.pid
+debug = notice
+foreground = yes
+output = /home/vcap/app/stunnel.log
+
+[hosted_graphite]
+accept = localhost:20030
+client = yes
+connect = <%= ENV.fetch('HOSTED_GRAPHITE_HOST') %>:20030
+CApath = /etc/ssl/certs
+


### PR DESCRIPTION
Use the apt buildpack to create a Ubuntu Bionic container with
carbon-relay-ng and stunnel. use erb for variables substitution. This
give us greater ability to configure both processes over the previous
docker container approach.

Note that Dropwizard apps emit their metrics on UDP so when adding cf
network-policies be sure to specify `--protocol udp`.