### PR TITLE
PP-6254 Run stunnel as a 'side-car'

### DIFF
--- a/paas/carbon-relay/manifest.yml
+++ b/paas/carbon-relay/manifest.yml
@@ -2,10 +2,15 @@
 applications:
   - name: carbon-relay
     health-check-type: process
+    instances: 2
     buildpacks:
     - https://github.com/cloudfoundry/apt-buildpack
     - https://github.com/cloudfoundry/binary-buildpack
-    command: ./start.sh
+    command: ./start_carbon_relay.sh
     env:
       HOSTED_GRAPHITE_HOST: ((hosted_graphite_host))
       HOSTED_GRAPHITE_API_KEY: ((hosted_graphite_api_key))
+    sidecars:
+      - name: stunnel
+        process_types: [ 'web' ]
+        command: ./start_stunnel.sh

--- a/paas/carbon-relay/start_carbon_relay.sh
+++ b/paas/carbon-relay/start_carbon_relay.sh
@@ -1,9 +1,5 @@
 #!/usr/bin/env bash
 set -o errexit -o nounset -o pipefail
 
-erb stunnel.conf.erb > stunnel.conf
 erb carbon-relay-ng.ini.erb > carbon-relay-ng.ini
-
-stunnel stunnel.conf hosted_graphite &
 carbon-relay-ng carbon-relay-ng.ini
-

--- a/paas/carbon-relay/start_stunnel.sh
+++ b/paas/carbon-relay/start_stunnel.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -o errexit -o nounset -o pipefail
+
+erb stunnel.conf.erb > stunnel.conf
+stunnel stunnel.conf hosted_graphite


### PR DESCRIPTION
This allows us to change instances, memory and cpu indendently to. CF  should
alert us and take steps to restart both carbon-relay and its sidecar stunnnel
should one or the other fail.