### PR TITLE
PP-6254 Add carbon-relay app to tf

### DIFF
--- a/paas/carbon-relay/carbon-relay-ng.ini.erb
+++ b/paas/carbon-relay/carbon-relay-ng.ini.erb
@@ -38,7 +38,7 @@ destinations = [
 
 [[rewriter]]
 old = '/^/'
-new = '<%= ENV.fetch('HOSTED_GRAPHITE_API_KEY') %>.'
+new = '<%= ENV.fetch('HOSTED_GRAPHITE_API_KEY') %>.paas.'
 not = ''
 max = -1
 

--- a/paas/carbon-relay/env-map.yml
+++ b/paas/carbon-relay/env-map.yml
@@ -1,0 +1,4 @@
+env_vars:
+  HOSTED_GRAPHITE_HOST:       '.[][] | select(.name == "carbon-relay-secret-service") | .credentials.hosted_graphite_host      '
+  HOSTED_GRAPHITE_API_KEY:    '.[][] | select(.name == "carbon-relay-secret-service") | .credentials.hosted_graphite_api_key   '
+  HOSTED_GRAPHITE_ACCOUNT_ID: '.[][] | select(.name == "carbon-relay-secret-service") | .credentials.hosted_graphite_account_id'

--- a/paas/carbon-relay/manifest.yml
+++ b/paas/carbon-relay/manifest.yml
@@ -4,13 +4,18 @@ applications:
     health-check-type: process
     instances: 2
     buildpacks:
+    - https://github.com/alphagov/env-map-buildpack.git#v2
     - https://github.com/cloudfoundry/apt-buildpack
     - https://github.com/cloudfoundry/binary-buildpack
     command: ./start_carbon_relay.sh
     env:
-      HOSTED_GRAPHITE_HOST: ((hosted_graphite_host))
-      HOSTED_GRAPHITE_API_KEY: ((hosted_graphite_api_key))
+      # Provided via the carbon-relay-secret-service
+      HOSTED_GRAPHITE_HOST:
+      HOSTED_GRAPHITE_API_KEY:
+      HOSTED_GRAPHITE_ACCOUNT_ID:
     sidecars:
       - name: stunnel
         process_types: [ 'web' ]
         command: ./start_stunnel.sh
+    services:
+      - carbon-relay-secret-service

--- a/paas/carbon-relay/stunnel.conf.erb
+++ b/paas/carbon-relay/stunnel.conf.erb
@@ -13,6 +13,6 @@ output = /home/vcap/app/stunnel.log
 [hosted_graphite]
 accept = localhost:20030
 client = yes
-connect = <%= ENV.fetch('HOSTED_GRAPHITE_HOST') %>:20030
+connect = <%= ENV.fetch('HOSTED_GRAPHITE_ACCOUNT_ID') + '.' + ENV.fetch('HOSTED_GRAPHITE_HOST') %>:20030
 CApath = /etc/ssl/certs
 

--- a/terraform/modules/paas/app-catalog-service.tf
+++ b/terraform/modules/paas/app-catalog-service.tf
@@ -26,6 +26,8 @@ locals {
     "cardid_data_test_card_data_location" = "http://${cloudfoundry_route.cardid_data.endpoint}:8080/test-cards/test-card-bin-ranges.csv"
     "cardid_data_worldpay_data_location"  = "http://${cloudfoundry_route.cardid_data.endpoint}:8080/worldpay/GENERIC2ISOCPTISSUERPREPAID.CSV"
     "cardid_data_discover_data_location"  = "http://${cloudfoundry_route.cardid_data.endpoint}:8080/discover/Merchant_Marketing.csv"
+    "carbon_relay_route"                  = "${cloudfoundry_route.carbon_relay.endpoint}"
+    "carbon_relay_port"                   = "2003"
   }
 }
 

--- a/terraform/modules/paas/carbon-relay.tf
+++ b/terraform/modules/paas/carbon-relay.tf
@@ -32,3 +32,30 @@ resource "cloudfoundry_user_provided_service" "carbon_relay_secret_service" {
   space       = data.cloudfoundry_space.space.id
   credentials = merge(module.carbon_relay_credentials.secrets, lookup(local.carbon_relay_credentials, "static_values"))
 }
+
+resource "cloudfoundry_network_policy" "carbon_relay" {
+  dynamic "policy" {
+    for_each = toset([
+      cloudfoundry_app.adminusers.id,
+      cloudfoundry_app.card_connector.id,
+      cloudfoundry_app.card_frontend.id,
+      cloudfoundry_app.cardid.id,
+      cloudfoundry_app.directdebit_connector.id,
+      cloudfoundry_app.directdebit_frontend.id,
+      cloudfoundry_app.ledger.id,
+      cloudfoundry_app.notifications.id,
+      cloudfoundry_app.products.id,
+      cloudfoundry_app.products_ui.id,
+      cloudfoundry_app.publicapi.id,
+      cloudfoundry_app.publicauth.id,
+      cloudfoundry_app.selfservice.id,
+      cloudfoundry_app.toolbox.id,
+    ])
+    content {
+      source_app      = policy.value
+      destination_app = cloudfoundry_app.carbon-relay.id
+      protocol        = "udp"
+      port            = "2003"
+    }
+  }
+}

--- a/terraform/modules/paas/carbon-relay.tf
+++ b/terraform/modules/paas/carbon-relay.tf
@@ -1,0 +1,34 @@
+locals {
+  carbon_relay_credentials = lookup(var.credentials, "carbon-relay")
+}
+
+resource "cloudfoundry_app" "carbon-relay" {
+  name    = "carbon-relay"
+  space   = data.cloudfoundry_space.space.id
+  stopped = true
+
+  lifecycle {
+    ignore_changes = [stopped, health_check_type]
+  }
+}
+
+resource "cloudfoundry_route" "carbon-relay" {
+  domain   = data.cloudfoundry_domain.internal.id
+  hostname = "carbon-relay${var.internal_hostname_suffix}"
+  space    = data.cloudfoundry_space.space.id
+
+  target {
+    app = cloudfoundry_app.carbon-relay.id
+  }
+}
+
+module "carbon_relay_credentials" {
+  source = "../credentials"
+  pay_low_pass_secrets = lookup(local.carbon_relay_credentials, "pay_low_pass_secrets")
+}
+
+resource "cloudfoundry_user_provided_service" "carbon_relay_secret_service" {
+  name        = "carbon-relay-secret-service"
+  space       = data.cloudfoundry_space.space.id
+  credentials = merge(module.carbon_relay_credentials.secrets, lookup(local.carbon_relay_credentials, "static_values"))
+}

--- a/terraform/modules/paas/carbon-relay.tf
+++ b/terraform/modules/paas/carbon-relay.tf
@@ -12,7 +12,7 @@ resource "cloudfoundry_app" "carbon-relay" {
   }
 }
 
-resource "cloudfoundry_route" "carbon-relay" {
+resource "cloudfoundry_route" "carbon_relay" {
   domain   = data.cloudfoundry_domain.internal.id
   hostname = "carbon-relay${var.internal_hostname_suffix}"
   space    = data.cloudfoundry_space.space.id

--- a/terraform/staging-paas/terraform.tfvars
+++ b/terraform/staging-paas/terraform.tfvars
@@ -178,5 +178,18 @@ credentials = {
       zendesk_user = "fake_user"
     }
   }
+  carbon-relay = {
+    pay_low_pass_secrets = {
+      hosted_graphite_api_key = "hosted_graphite/prod/api_key"
+      hosted_graphite_account_id = "hosted_graphite/prod/account_id"
+    }
+
+    pay_dev_pass_secrets = {
+    }
+
+    static_values = {
+      hosted_graphite_host = "carbon.hostedgraphite.com"
+    }
+  }
 }
 


### PR DESCRIPTION
**Commit No. 1**
Add `carbon-relay` module to create empty app with route and
corresponding secret service. Use the env-map buildpack to extract
hosted graphite vars from VCAP_SERVICES.

Tested by running tf in staging. `carbon-relay` starts along with its side car stunnel process and envs are correctly set.

**Commit No. 2**
Added carbon-relay route and port to app-catalog, confirmed its present:
```
gds5062 > cf curl /v2/service_instances/8bd15004-0ad9-41d0-a19e-2a684973d7f8 | grep carbon_relay
         "carbon_relay_port": "2003",
         "carbon_relay_route": "carbon-relay-stg.apps.internal",
```
**Commit No. 3** 
Add network policies to carbon-relay. Might be a better way to iterate over each instance of `cloudfoundry_app` resource without having to create the set although I cannot find it in docs, seemingly need to reference any tf resource byboth the type and instance name...
