### PR TITLE
PP-6254: Start carbon-relay apps using exec

### DIFF
--- a/paas/carbon-relay/start_carbon_relay.sh
+++ b/paas/carbon-relay/start_carbon_relay.sh
@@ -2,4 +2,4 @@
 set -o errexit -o nounset -o pipefail
 
 erb carbon-relay-ng.ini.erb > carbon-relay-ng.ini
-carbon-relay-ng carbon-relay-ng.ini
+exec carbon-relay-ng carbon-relay-ng.ini

--- a/paas/carbon-relay/start_stunnel.sh
+++ b/paas/carbon-relay/start_stunnel.sh
@@ -2,4 +2,4 @@
 set -o errexit -o nounset -o pipefail
 
 erb stunnel.conf.erb > stunnel.conf
-stunnel stunnel.conf hosted_graphite
+exec stunnel stunnel.conf hosted_graphite


### PR DESCRIPTION
Replaces the bash startup script process id with the application. This ensures the application is able to correctly receive process signals from the OS.