### PR TITLE
Create Splunk log service instance in cde & non cde spaces

### DIFF
--- a/terraform/modules/paas/splunk-log-drain.tf
+++ b/terraform/modules/paas/splunk-log-drain.tf
@@ -1,0 +1,15 @@
+data "cloudfoundry_service" "splunk" {
+  name = "splunk"
+}
+
+resource "cloudfoundry_service_instance" "splunk_log_service" {
+  name         = "splunk-log-service"
+  service_plan = data.cloudfoundry_service.splunk.service_plans["unlimited"]
+  space        = data.cloudfoundry_space.space.id
+}
+
+resource "cloudfoundry_service_instance" "cde_splunk_log_service" {
+  name         = "splunk-log-service"
+  service_plan = data.cloudfoundry_service.splunk.service_plans["unlimited"]
+  space        = data.cloudfoundry_space.cde_space.id
+}


### PR DESCRIPTION
Creates two service instances (CDE & non-CDE) for shipping application logs to Splunk via Techops /Cyber Splunk service broker. 

https://github.com/alphagov/tech-ops/tree/master/cyber-security/components/csls-splunk-broker