### PR TITLE
Use CF CLI v7 with optional arguments

### DIFF
--- a/ci/pipelines/deploy.yml
+++ b/ci/pipelines/deploy.yml
@@ -737,16 +737,14 @@ jobs:
       - task: extract-adminusers-artefact
         file: omnibus/ci/tasks/extract-artefact.yml
         input_mapping: { git-release: git-adminusers-pre-release }
-      - put: paas-staging
+      - task: deploy-to-paas-staging
+        file: omnibus/ci/tasks/cf-v3-push.yml
         params: &push-app-config
-          command: push
-          path: artefact/target/pay-*-allinone.jar
-          manifest: artefact/manifest.yml
-          vars_files:
-            - omnibus/paas/env_variables/staging.yml
-          vars:
-            db_name: adminusers
-            db_user: adminusers
+          <<: *cf-creds
+          CF_SPACE: staging
+          APP_NAME: adminusers
+          PATH: artefact/target/pay-*-allinone.jar
+          VARS_FILE: omnibus/paas/env_variables/staging.yml
 
   - name: deploy-cardid-data-staging
     serial_groups: [cardid-data-stg]
@@ -773,10 +771,12 @@ jobs:
       - task: extract-cardid-artefact
         file: omnibus/ci/tasks/extract-artefact.yml
         input_mapping: { git-release: git-cardid-pre-release }
-      - put: paas-staging
+      - task: deploy-to-paas-staging
+        file: omnibus/ci/tasks/cf-v3-push.yml
         params:
           <<: *push-app-config
-          space: staging-cde
+          APP_NAME: cardid
+          CF_SPACE: staging-cde
 
   - name: deploy-directdebit-frontend-staging
     serial_groups: [directdebit-frontend-stg]
@@ -803,13 +803,12 @@ jobs:
       - task: extract-card-connector-artefact
         file: omnibus/ci/tasks/extract-artefact.yml
         input_mapping: { git-release: git-card-connector-pre-release }
-      - put: paas-staging
+      - task: deploy-to-paas-staging
+        file: omnibus/ci/tasks/cf-v3-push.yml
         params:
           <<: *push-app-config
-          space: staging-cde
-          vars:
-            db_name: connector
-            db_user: connector
+          APP_NAME: 
+          CF_SPACE: staging-cde
 
   - name: deploy-card-frontend-staging
     serial_groups: [card-frontend-stg]
@@ -837,12 +836,12 @@ jobs:
       - task: extract-directdebit-connector-artefact
         file: omnibus/ci/tasks/extract-artefact.yml
         input_mapping: { git-release: git-directdebit-connector-pre-release }
-      - put: paas-staging
+      - task: deploy-to-paas-staging
+        file: omnibus/ci/tasks/cf-v3-push.yml
         params:
           <<: *push-app-config
-          vars:
-            db_name: directdebit-connector
-            db_user: directdebit-connector
+          APP_NAME: directdebit-connector 
+          CF_SPACE: staging
 
   - name: deploy-ledger-staging
     serial_groups: [ledger-stg]
@@ -854,12 +853,12 @@ jobs:
       - task: extract-ledger-artefact
         file: omnibus/ci/tasks/extract-artefact.yml
         input_mapping: { git-release: git-ledger-pre-release }
-      - put: paas-staging
+      - task: deploy-to-paas-staging
+        file: omnibus/ci/tasks/cf-v3-push.yml
         params:
           <<: *push-app-config
-          vars:
-            db_name: ledger
-            db_user: ledger
+          APP_NAME: ledger 
+          CF_SPACE: staging
 
   - name: deploy-products-staging
     serial_groups: [products-stg]
@@ -871,12 +870,12 @@ jobs:
       - task: extract-products-artefact
         file: omnibus/ci/tasks/extract-artefact.yml
         input_mapping: { git-release: git-products-pre-release }
-      - put: paas-staging
+      - task: deploy-to-paas-staging
+        file: omnibus/ci/tasks/cf-v3-push.yml
         params:
           <<: *push-app-config
-          vars:
-            db_name: products
-            db_user: products
+          APP_NAME: products 
+          CF_SPACE: staging
 
   - name: deploy-products-ui-staging
     serial_groups: [products-ui-stg]
@@ -903,9 +902,12 @@ jobs:
       - task: extract-publicapi-artefact
         file: omnibus/ci/tasks/extract-artefact.yml
         input_mapping: { git-release: git-publicapi-pre-release }
-      - put: paas-staging
+      - task: deploy-to-paas-staging
+        file: omnibus/ci/tasks/cf-v3-push.yml
         params:
           <<: *push-app-config
+          APP_NAME: products-ui 
+          CF_SPACE: staging
 
   - name: deploy-publicauth-staging
     serial_groups: [publicauth-stg]
@@ -917,9 +919,12 @@ jobs:
       - task: extract-publicauth-artefact
         file: omnibus/ci/tasks/extract-artefact.yml
         input_mapping: { git-release: git-publicauth-pre-release }
-      - put: paas-staging
+      - task: deploy-to-paas-staging
+        file: omnibus/ci/tasks/cf-v3-push.yml
         params:
           <<: *push-app-config
+          APP_NAME: publicauth 
+          CF_SPACE: staging
 
   - name: deploy-selfservice-staging
     serial_groups: [selfservice-stg]
@@ -973,18 +978,14 @@ jobs:
         trigger: true
         params:
           skip_download: true
-      - put: app
-        resource: paas-staging
-        params: &docker-app
-          command: push
-          app_name: notifications
-          manifest: omnibus/paas/pay-apps.yml
-          docker_password: ((docker-password))
-          vars:
-            space: staging
-            docker-username: ((docker-username))
-          vars_files:
-            - omnibus/paas/env_variables/staging.yml
+     - task: deploy-to-paas-staging
+        file: omnibus/ci/tasks/cf-v3-push.yml
+        params:
+          <<: *push-app-config
+          APP_NAME: notifications 
+          CF_SPACE: staging
+          CF_DOCKER_PASSWORD: ((docker-password))
+          DOCKER_USERNAME: ((docker-username))
 
   - name: deploy-sqs-staging
     plan:

--- a/ci/pipelines/deploy.yml
+++ b/ci/pipelines/deploy.yml
@@ -780,6 +780,8 @@ jobs:
           <<: *push-app-config
           APP_NAME: cardid
           CF_SPACE: staging-cde
+          PATH: artefact/target/pay-*-allinone.jar
+          VARS_FILE: omnibus/paas/env_variables/staging.yml
 
   - name: deploy-directdebit-frontend-staging
     serial_groups: [directdebit-frontend-stg]
@@ -791,10 +793,13 @@ jobs:
       - task: extract-directdebit-frontend-artefact
         file: omnibus/ci/tasks/extract-artefact.yml
         input_mapping: { git-release: git-directdebit-frontend-pre-release }
-      - put: paas-staging
+      - task: deploy-to-paas-staging
+        file: omnibus/ci/tasks/cf-v3-push.yml
         params:
           <<: *push-app-config
-          path: artefact
+          APP_NAME: directdebit-frontend
+          CF_SPACE: staging
+          VARS_FILE: omnibus/paas/env_variables/staging.yml
 
   - name: deploy-card-connector-staging
     serial_groups: [card-connector-stg]
@@ -810,8 +815,10 @@ jobs:
         file: omnibus/ci/tasks/cf-v3-push.yml
         params:
           <<: *push-app-config
-          APP_NAME: 
+          APP_NAME: card-connector
           CF_SPACE: staging-cde
+          PATH: artefact/target/pay-*-allinone.jar
+          VARS_FILE: omnibus/paas/env_variables/staging.yml
 
   - name: deploy-card-frontend-staging
     serial_groups: [card-frontend-stg]
@@ -823,11 +830,13 @@ jobs:
       - task: extract-card-frontend-artefact
         file: omnibus/ci/tasks/extract-artefact.yml
         input_mapping: { git-release: git-card-frontend-pre-release }
-      - put: paas-staging
+      - task: deploy-to-paas-staging
+        file: omnibus/ci/tasks/cf-v3-push.yml
         params:
           <<: *push-app-config
-          space: staging-cde
-          path: artefact
+          APP_NAME: card-frontend
+          CF_SPACE: staging-cde
+          VARS_FILE: omnibus/paas/env_variables/staging.yml
 
   - name: deploy-directdebit-connector-staging
     serial_groups: [directdebit-connector-stg]
@@ -845,6 +854,8 @@ jobs:
           <<: *push-app-config
           APP_NAME: directdebit-connector 
           CF_SPACE: staging
+          PATH: artefact/target/pay-*-allinone.jar
+          VARS_FILE: omnibus/paas/env_variables/staging.yml
 
   - name: deploy-ledger-staging
     serial_groups: [ledger-stg]
@@ -862,6 +873,8 @@ jobs:
           <<: *push-app-config
           APP_NAME: ledger 
           CF_SPACE: staging
+          PATH: artefact/target/pay-*-allinone.jar
+          VARS_FILE: omnibus/paas/env_variables/staging.yml
 
   - name: deploy-products-staging
     serial_groups: [products-stg]
@@ -879,6 +892,8 @@ jobs:
           <<: *push-app-config
           APP_NAME: products 
           CF_SPACE: staging
+          PATH: artefact/target/pay-*-allinone.jar
+          VARS_FILE: omnibus/paas/env_variables/staging.yml
 
   - name: deploy-products-ui-staging
     serial_groups: [products-ui-stg]
@@ -890,10 +905,13 @@ jobs:
       - task: extract-products-ui-artefact
         file: omnibus/ci/tasks/extract-artefact.yml
         input_mapping: { git-release: git-products-ui-pre-release }
-      - put: paas-staging
+      - task: deploy-to-paas-staging
+        file: omnibus/ci/tasks/cf-v3-push.yml
         params:
           <<: *push-app-config
-          path: artefact
+          APP_NAME: products-ui 
+          CF_SPACE: staging
+          VARS_FILE: omnibus/paas/env_variables/staging.yml
 
   - name: deploy-publicapi-staging
     serial_groups: [publicapi-stg]
@@ -909,8 +927,10 @@ jobs:
         file: omnibus/ci/tasks/cf-v3-push.yml
         params:
           <<: *push-app-config
-          APP_NAME: products-ui 
+          APP_NAME: publicapi 
           CF_SPACE: staging
+          PATH: artefact/target/pay-*-allinone.jar
+          VARS_FILE: omnibus/paas/env_variables/staging.yml
 
   - name: deploy-publicauth-staging
     serial_groups: [publicauth-stg]
@@ -928,6 +948,8 @@ jobs:
           <<: *push-app-config
           APP_NAME: publicauth 
           CF_SPACE: staging
+          PATH: artefact/target/pay-*-allinone.jar
+          VARS_FILE: omnibus/paas/env_variables/staging.yml
 
   - name: deploy-selfservice-staging
     serial_groups: [selfservice-stg]
@@ -939,10 +961,13 @@ jobs:
       - task: download-selfservice-artefact
         file: omnibus/ci/tasks/extract-artefact.yml
         input_mapping: { git-release: git-selfservice-pre-release }
-      - put: paas-staging
+      - task: deploy-to-paas-staging
+        file: omnibus/ci/tasks/cf-v3-push.yml
         params:
           <<: *push-app-config
-          path: artefact
+          APP_NAME: selfservice 
+          CF_SPACE: staging
+          VARS_FILE: omnibus/paas/env_variables/staging.yml
 
   - name: deploy-carbon-relay-staging
     serial_groups: [carbon-relay-stg]
@@ -968,10 +993,13 @@ jobs:
       - task: download-toolbox-artefact
         file: omnibus/ci/tasks/extract-artefact.yml
         input_mapping: { git-release: git-toolbox-pre-release }
-      - put: paas-staging
+      - task: deploy-to-paas-staging
+        file: omnibus/ci/tasks/cf-v3-push.yml
         params:
           <<: *push-app-config
-          path: artefact
+          APP_NAME: selfservice 
+          CF_SPACE: staging
+          VARS_FILE: omnibus/paas/env_variables/staging.yml
 
   - name: deploy-notifications-staging
     serial_groups: [notifications-stg]
@@ -989,6 +1017,8 @@ jobs:
           CF_SPACE: staging
           CF_DOCKER_PASSWORD: ((docker-password))
           DOCKER_USERNAME: ((docker-username))
+          PATH: artefact/target/pay-*-allinone.jar
+          VARS_FILE: omnibus/paas/env_variables/staging.yml
 
   - name: deploy-sqs-staging
     plan:

--- a/ci/pipelines/deploy.yml
+++ b/ci/pipelines/deploy.yml
@@ -1010,7 +1010,7 @@ jobs:
         trigger: true
         params:
           skip_download: true
-     - task: deploy-to-paas-staging
+      - task: deploy-to-paas-staging
         file: omnibus/ci/tasks/cf-v3-push.yml
         params:
           <<: *push-app-config
@@ -1027,10 +1027,13 @@ jobs:
       - put: app
         resource: paas-staging
         params:
-          <<: *docker-app
+          command: push
+          docker_password: ((docker-password))
           docker-username: ((docker-username))
           app_name: sqs
           manifest: omnibus/paas/fake-sqs.yml
+          vars:
+            space: staging
 
   - name: deploy-metric-exporter-staging
     serial_groups: [metric-exporter-stg]

--- a/ci/pipelines/deploy.yml
+++ b/ci/pipelines/deploy.yml
@@ -155,7 +155,7 @@ resources:
 
   - name: carbon-relay-source
     type: git
-    icon: gihub-circle
+    icon: github-circle
     source:
       uri: https://github.com/alphagov/pay-omnibus
       branch: develop
@@ -975,13 +975,14 @@ jobs:
       - get: carbon-relay-source
         trigger: true
       - get: omnibus
-      - task: deploy-to-paas
-        file: omnibus/ci/tasks/cf-v3-deploy.yml
+      - task: deploy-to-paas-staging
+        file: omnibus/ci/tasks/cf-v3-push.yml
+        input_mapping: { artefact: "carbon-relay-source" }
         params:
-          <<: *cf-creds
+          <<: *push-app-config
+          APP_NAME: metric-exporter          
           CF_SPACE: staging
           MANIFEST_PATH: omnibus/paas/carbon-relay
-          APP_NAME: carbon-relay
 
   - name: deploy-toolbox-staging
     serial_groups: [toolbox-stg]
@@ -1051,11 +1052,14 @@ jobs:
           run:
             path: cp
             args: ["omnibus/paas/metric-exporter/env-map.yml", "metric-exporter-source"]
-      - put: paas-staging
+      - task: deploy-to-paas-staging
+        file: omnibus/ci/tasks/cf-v3-push.yml
+        input_mapping: { artefact: "metric-exporter-source" }
         params:
-          command: push
-          path: metric-exporter-source
-          manifest: omnibus/paas/metric-exporter/manifest.yml
+          <<: *push-app-config
+          APP_NAME: metric-exporter          
+          CF_SPACE: staging
+          MANIFEST_PATH: omnibus/paas/metric-exporter
 
   # Smoke Tests
   - name: deploy-selenium-hub

--- a/ci/pipelines/deploy.yml
+++ b/ci/pipelines/deploy.yml
@@ -749,14 +749,17 @@ jobs:
   - name: deploy-cardid-data-staging
     serial_groups: [cardid-data-stg]
     plan:
+      - get: omnibus
       - get: cardid-data-source
         trigger: true
-      - put: paas-staging
-        params:
-          command: push
-          path: cardid-data-source/sources
-          manifest: cardid-data-source/manifest.yml
-          space: staging
+      - task: deploy-to-paas-staging
+        file: omnibus/ci/tasks/cf-v3-push.yml
+        input_mapping: { artefact: cardid-data-source }
+        params: &push-app-config
+          <<: *cf-creds
+          CF_SPACE: staging
+          APP_NAME: cardid-data
+          PATH: artefact/sources
 
   - name: deploy-cardid-staging
     serial_groups: [cardid-stg]

--- a/ci/tasks/cf-v3-deploy.yml
+++ b/ci/tasks/cf-v3-deploy.yml
@@ -18,6 +18,9 @@ params:
   CF_PASSWORD: ((cf-password))
   CF_ORG:
   CF_SPACE:
+  CF_DOCKER_PASSWORD:
+  DOCKER_IMAGE:
+  DOCKER_USERNAME:
   MANIFEST_PATH: artefact
   MANIFEST_FILE: manifest.yml
   APP_NAME:
@@ -41,5 +44,7 @@ run:
       args+=(--manifest "$MANIFEST_PATH/$MANIFEST_FILE")
       [ -n "$VARS_FILE" ] && args+=(--vars-file "$VARS_FILE")
       [ -n "$ZDT" ] && args+=(--strategy rolling)
+      [ -n "$DOCKER_USERNAME" ] && args+=(--docker-username "$DOCKER_USERNAME")
+      [ -n "$DOCKER_IMAGE" ] && args+=(--docker-image "$DOCKER_IMAGE")
 
       cf push "${args[@]}"

--- a/ci/tasks/cf-v3-deploy.yml
+++ b/ci/tasks/cf-v3-deploy.yml
@@ -1,13 +1,15 @@
 platform: linux
 
 image_resource:
-  type: docker-image
-  source: { repository: governmentpaas/cf-cli }
+  type: registry-image
+  source:
+    repository: governmentpaas/cf-cli
+    tag: cf7
 
 inputs:
   - name: omnibus
     optional: true
-  - name: workdir
+  - name: artefact
     optional: true
 
 params:
@@ -16,9 +18,12 @@ params:
   CF_PASSWORD: ((cf-password))
   CF_ORG:
   CF_SPACE:
-  MANIFEST_PATH:
+  MANIFEST_PATH: artefact
   MANIFEST_FILE: manifest.yml
   APP_NAME:
+  PATH: artefact
+  VARS_FILE:
+  ZDT:
 
 run:
   path: bash
@@ -29,6 +34,12 @@ run:
       cf login -a "$CF_API" \
         -u "$CF_USERNAME" -p "$CF_PASSWORD" \
         -o "$CF_ORG" -s "$CF_SPACE"
-      cd $MANIFEST_PATH
-      cf v3-apply-manifest -f "$MANIFEST_FILE"
-      cf v3-push "$APP_NAME"
+
+      args=()
+      args+=("$APP_NAME")
+      args+=(--path "$PATH")
+      args+=(--manifest "$MANIFEST_PATH/$MANIFEST_FILE")
+      [ -n "$VARS_FILE" ] && args+=(--vars-file "$VARS_FILE")
+      [ -n "$ZDT" ] && args+=(--strategy rolling)
+
+      cf push "${args[@]}"


### PR DESCRIPTION
Apps are now created using the CF v3 API. 
This PR updates Concourse pipelines and tasks to use V7 CF CLI  as this supports the vars-file option and ZDT functionality which was missing from v6 v3-push command.