### PR TITLE
PP-6366: Add makefile to automate installation of TF plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Pay on PaaS.
 - `local`: Stuff for local testing and development
 - `paas`: Cloud Foundry manifests for Pay services
 - `secrets`: Secrets store using [pass](https://passwordstore.org)
+- `terraform`: Terraform for managing Cloudfoundry & AWS infrastructure
 
 ## Documentation
 

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -1,0 +1,17 @@
+default: install-providers
+
+.PHONY: install-paas-provider
+install-pass-provider:
+	go get github.com/camptocamp/terraform-provider-pass
+	GOBIN=~/.terraform.d/plugins/darwin_amd64 go install github.com/camptocamp/terraform-provider-pass
+
+.PHONY: install-cf-provider
+install-cf-provider:
+	mkdir -p ${GOPATH}/src/github.com/terraform-providers
+	if [ ! -d "${GOPATH}/src/github.com/terraform-providers/terrform-provider-cloudfoundry" ]; then \
+    	git clone -b v3_app_resource git@github.com:alphagov/terraform-provider-cf.git ${GOPATH}/src/github.com/terraform-providers/terrform-provider-cloudfoundry; \
+	fi
+	cd ${GOPATH}/src/github.com/terraform-providers/terrform-provider-cloudfoundry; GOBIN=~/.terraform.d/plugins/darwin_amd64 go install
+
+.PHONY: install-providers
+install-providers: install-pass-provider install-cf-provider

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -4,14 +4,16 @@ default: install-providers
 install-pass-provider:
 	go get github.com/camptocamp/terraform-provider-pass
 	GOBIN=~/.terraform.d/plugins/darwin_amd64 go install github.com/camptocamp/terraform-provider-pass
+	mv ~/.terraform.d/plugins/darwin_amd64/terraform-provider-pass ~/.terraform.d/plugins/darwin_amd64/terraform-provider-pass_v1.2.1
 
 .PHONY: install-cf-provider
 install-cf-provider:
 	mkdir -p ${GOPATH}/src/github.com/terraform-providers
-	if [ ! -d "${GOPATH}/src/github.com/terraform-providers/terrform-provider-cloudfoundry" ]; then \
-    	git clone -b v3_app_resource git@github.com:alphagov/terraform-provider-cf.git ${GOPATH}/src/github.com/terraform-providers/terrform-provider-cloudfoundry; \
+	if [ ! -d "${GOPATH}/src/github.com/terraform-providers/terraform-provider-cloudfoundry" ]; then \
+    	git clone -b v3_app_resource git@github.com:alphagov/terraform-provider-cf.git ${GOPATH}/src/github.com/terraform-providers/terraform-provider-cloudfoundry; \
 	fi
-	cd ${GOPATH}/src/github.com/terraform-providers/terrform-provider-cloudfoundry; GOBIN=~/.terraform.d/plugins/darwin_amd64 go install
+	cd ${GOPATH}/src/github.com/terraform-providers/terraform-provider-cloudfoundry; GOBIN=~/.terraform.d/plugins/darwin_amd64 go install
+	mv ~/.terraform.d/plugins/darwin_amd64/terraform-provider-cloudfoundry ~/.terraform.d/plugins/darwin_amd64/terraform-provider-cloudfoundry_v0.11.0
 
 .PHONY: install-providers
 install-providers: install-pass-provider install-cf-provider

--- a/terraform/modules/credentials/main.tf
+++ b/terraform/modules/credentials/main.tf
@@ -7,23 +7,25 @@ locals {
 }
 
 provider "pass" {
-  store_dir = "../../../pay-low-pass"
+  version       = "~> 1.2"
+  store_dir     = "../../../pay-low-pass"
   refresh_store = false
 }
 
 provider "pass" {
-  store_dir = "../../../pay-dev-pass"
+  version       = "~> 1.2"
+  store_dir     = "../../../pay-dev-pass"
   refresh_store = false
-  alias = "dev-pass"
+  alias         = "dev-pass"
 }
 
 data "pass_password" "secret" {
   for_each = var.pay_low_pass_secrets
-  path = each.value
+  path     = each.value
 }
 
 data "pass_password" "dev_secret" {
   for_each = var.pay_dev_pass_secrets
-  path = each.value
+  path     = each.value
   provider = pass.dev-pass
 }


### PR DESCRIPTION
**What is it?**
Adds a makefile to automate installation steps for Terraform Cloudfoundry & Pass provider plugins.

**How to test**
- Checkout this PR branch.
- `cd terraform`
- run `make`
- `cd terraform/paas-staging`
- `aws-vault exec <env> -- terrafrom init` 

- test the provider configuration `aws-vault exec <env> -- terraform providers`