### PR TITLE
Prevent destruction of Splunk logdrain service instances

### DIFF
--- a/terraform/modules/paas/splunk-log-drain.tf
+++ b/terraform/modules/paas/splunk-log-drain.tf
@@ -3,13 +3,15 @@ data "cloudfoundry_service" "splunk" {
 }
 
 resource "cloudfoundry_service_instance" "splunk_log_service" {
-  name         = "splunk-log-service"
-  service_plan = data.cloudfoundry_service.splunk.service_plans["unlimited"]
-  space        = data.cloudfoundry_space.space.id
+  name            = "splunk-log-service"
+  service_plan    = data.cloudfoundry_service.splunk.service_plans["unlimited"]
+  space           = data.cloudfoundry_space.space.id
+  prevent_destroy = true
 }
 
 resource "cloudfoundry_service_instance" "cde_splunk_log_service" {
-  name         = "splunk-log-service"
-  service_plan = data.cloudfoundry_service.splunk.service_plans["unlimited"]
-  space        = data.cloudfoundry_space.cde_space.id
+  name            = "splunk-log-service"
+  service_plan    = data.cloudfoundry_service.splunk.service_plans["unlimited"]
+  space           = data.cloudfoundry_space.cde_space.id
+  prevent_destroy = true
 }


### PR DESCRIPTION
The GUIDs generated on initial creation of the services are used to configure our static Splunk index names. Destruction and recreation of the service instance would generate a new GUID and cause logs to be sent to the incorrect index.

Discussed with @chrisfarms 