### PR TITLE
PP-6371: Create PR pipeline

### DIFF
--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -8,7 +8,7 @@ resources:
   - &pull-request
     name: card-connector-pull-request
     type: pull-request
-    icon: github-cirle
+    icon: github-circle
     check_every: 1h
     source: &pull-request-source
       repository: alphagov/pay-connector
@@ -51,12 +51,35 @@ resources:
       repository: alphagov/pay-direct-debit-connector
 
   - <<: *pull-request
-    name: frontend-pull-request
+    name: card-frontend-pull-request
     source:
       <<: *pull-request-source
       repository: alphagov/pay-frontend
+
+  - <<: *pull-request
+    name: selfservice-pull-request
+    source:
+      <<: *pull-request-source
+      repository: alphagov/pay-selfservice
+
+  - <<: *pull-request
+    name: toolbox-pull-request
+    source:
+      <<: *pull-request-source
+      repository: alphagov/pay-toolbox
+
+  - <<: *pull-request
+    name: dd-frontend-pull-request
+    source:
+      <<: *pull-request-source
+      repository: alphagov/pay-direct-debit-frontend
+
 jobs:
-- name: card-connector-test
+- &pull-request-test
+  name: card-connector-test
+  max_in_flight: 3
+  build_log_retention:
+    builds: 500
   plan:
   - &pull-request-get
     get: src
@@ -70,7 +93,7 @@ jobs:
       path: src
       status: pending
   - &java-test
-    task: test
+    task: run-tests
     privileged: true
     config:
       container_limits: {}
@@ -120,7 +143,8 @@ jobs:
       path: src
       status: success
 
-- name: adminusers-test
+- <<: *pull-request-test
+  name: adminusers-test
   plan:
   - <<: *pull-request-get
     resource: adminusers-pull-request
@@ -135,7 +159,8 @@ jobs:
   - <<: *send-success-status
     put: adminusers-pull-request
 
-- name: cardid-test
+- <<: *pull-request-test
+  name: cardid-test
   plan:
   - <<: *pull-request-get
     resource: cardid-pull-request
@@ -150,7 +175,8 @@ jobs:
   - <<: *send-success-status
     put: cardid-pull-request
 
-- name: pay-direct-debit-connector-test
+- <<: *pull-request-test
+  name: pay-direct-debit-connector-test
   plan:
   - <<: *pull-request-get
     resource: direct-debit-connector-pull-request
@@ -165,7 +191,8 @@ jobs:
   - <<: *send-success-status
     put: direct-debit-connector-pull-request
 
-- name: ledger-test
+- <<: *pull-request-test
+  name: ledger-test
   plan:
   - <<: *pull-request-get
     resource: ledger-pull-request
@@ -180,7 +207,8 @@ jobs:
   - <<: *send-success-status
     put: ledger-pull-request
 
-- name: publicauth-test
+- <<: *pull-request-test
+  name: publicauth-test
   plan:
   - <<: *pull-request-get
     resource: publicauth-pull-request
@@ -195,7 +223,8 @@ jobs:
   - <<: *send-success-status
     put: publicauth-pull-request
 
-- name: publicapi-test
+- <<: *pull-request-test
+  name: publicapi-test
   plan:
   - <<: *pull-request-get
     resource: publicapi-pull-request
@@ -210,30 +239,27 @@ jobs:
   - <<: *send-success-status
     put: publicapi-pull-request
 
-- name: frontend-test
+- <<: *pull-request-test
+  name: card-frontend-test
   plan:
   - <<: *pull-request-get
-    resource: frontend-pull-request
+    resource: card-frontend-pull-request
   - <<: *send-pending-status
-    put: frontend-pull-request
+    put: card-frontend-pull-request
   - &node-test
     task: test
     privileged: true
     config:
       platform: linux
-
       image_resource:
         type: docker-image
         source:
           repository: node
           tag: 12-alpine
-
       inputs:
         - name: src
-
       caches:
         - path: npm_cache
-
       run:
         path: sh
         dir: src
@@ -260,9 +286,57 @@ jobs:
             npm run compile
             npm test -- --forbid-only --forbid-pending
     on_failure:
-      put: frontend-pull-request
+      put: card-frontend-pull-request
       params:
         path: src
         status: failure
   - <<: *send-success-status
-    put: frontend-pull-request
+    put: card-frontend-pull-request
+
+- <<: *pull-request-test
+  name: selfservice-test
+  plan:
+  - <<: *pull-request-get
+    resource: selfservice-pull-request
+  - <<: *send-pending-status
+    put: selfservice-pull-request
+  - <<: *node-test
+    on_failure:
+      put: selfservice-pull-request
+      params:
+        path: src
+        status: failure
+  - <<: *send-success-status
+    put: selfservice-pull-request
+
+- <<: *pull-request-test
+  name: toolbox-test
+  plan:
+  - <<: *pull-request-get
+    resource: toolbox-pull-request
+  - <<: *send-pending-status
+    put: toolbox-pull-request
+  - <<: *node-test
+    on_failure:
+      put: toolbox-pull-request
+      params:
+        path: src
+        status: failure
+  - <<: *send-success-status
+    put: toolbox-pull-request
+
+- <<: *pull-request-test
+  name: dd-frontend-test
+  plan:
+  - <<: *pull-request-get
+    resource: dd-frontend-pull-request
+  - <<: *send-pending-status
+    put: dd-frontend-pull-request
+  - <<: *node-test
+    on_failure:
+      put: dd-frontend-pull-request
+      params:
+        path: src
+        status: failure
+  - <<: *send-success-status
+    put: dd-frontend-pull-request

--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -232,7 +232,7 @@ jobs:
         - name: src
 
       caches:
-        - path: src/node_modules
+        - path: npm_cache
 
       run:
         path: sh
@@ -241,12 +241,22 @@ jobs:
           - -ec
           - |
             set -o errexit -o nounset -o pipefail
-            node --version
-            npm --version
-            apk add --virtual build-dependencies --update python build-base libexecinfo-dev ruby
+            echo "node: $(node --version)"
+            echo "npm: $(npm --version)"
+
+            apk update
+            apk upgrade
+            apk add --update --virtual build-dependencies build-base
+            apk add --update bash ca-certificates wget python
+
+            # For Pact. See: https://docs.pact.io/docker#alpine-linux
+            wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub
+            wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.29-r0/glibc-2.29-r0.apk
+            apk add glibc-2.29-r0.apk
+
             npm config set cache ../npm_cache
             npm rebuild node-sass
-            npm install
+            npm ci
             npm run compile
             npm test -- --forbid-only --forbid-pending
     on_failure:

--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -16,33 +16,60 @@ resources:
 jobs:
 - name: card-connector-test
   plan:
-  - get: card-connector-pull-request
+  - get: src
+    resource: card-connector-pull-request
     trigger: true
     version: every
+    name: src
   - put: card-connector-pull-request
     params:
-      path: card-connector-pull-request
+      path: src
       status: pending
-  - task: unit-test
+  - task: test
+    privileged: true
     config:
-      platform: linux
+      container_limits: {}
       image_resource:
-        type: docker-image
-        source: {repository: maven, tag: "latest"}
+        type: registry-image
+        source:
+          repository: amidos/dcind
+      caches:
+        - path: src/.m2
       inputs:
-        - name: card-connector-pull-request
+        - name: src
+      platform: linux
       run:
-        path: /bin/sh
+        path: bash
         args:
-          - -xce
-          - |
-            echo "HELLO"
+        - -ec
+        - |
+          apk --no-cache add openjdk11 maven --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community
+
+          source /docker-lib.sh
+          start_docker
+
+          cd src
+
+          export MAVEN_HOME=/usr/lib/mvn
+          export PATH=$MAVEN_HOME/bin:$PATH
+          export MAVEN_REPO="$PWD/.m2"
+
+          cat <<'EOF' >settings.xml
+          <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                                    https://maven.apache.org/xsd/settings-1.0.0.xsd">
+                <localRepository>${env.MAVEN_REPO}</localRepository>
+          </settings>
+          EOF
+
+          mvn --global-settings settings.xml clean verify
     on_failure:
       put: card-connector-pull-request
       params:
-        path: card-connector-pull-request
+        path: src
         status: failure
   - put: card-connector-pull-request
     params:
-      path: card-connector-pull-request
+      path: src
       status: success

--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -20,6 +20,35 @@ resources:
       <<: *pull-request-source
       repository: alphagov/pay-adminusers
 
+  - <<: *pull-request
+    name: publicapi-pull-request
+    source:
+      <<: *pull-request-source
+      repository: alphagov/pay-publicapi
+
+  - <<: *pull-request
+    name: ledger-pull-request
+    source:
+      <<: *pull-request-source
+      repository: alphagov/pay-ledger
+  
+  - <<: *pull-request
+    name: publicauth-pull-request
+    source:
+      <<: *pull-request-source
+      repository: alphagov/pay-publicauth
+
+  - <<: *pull-request
+    name: cardid-pull-request
+    source:
+      <<: *pull-request-source
+      repository: alphagov/pay-cardid
+
+  - <<: *pull-request
+    name: direct-debit-connector-pull-request
+    source:
+      <<: *pull-request-source
+      repository: alphagov/pay-direct-debit-connector
 
 jobs:
 - name: card-connector-test
@@ -100,3 +129,78 @@ jobs:
         status: failure
   - <<: *send-success-status
     put: adminusers-pull-request
+
+- name: cardid-test
+  plan:
+  - <<: *pull-request-get
+    resource: cardid-pull-request
+  - <<: *send-pending-status
+    put: cardid-pull-request
+  - <<: *java-test
+    on_failure:
+      put: cardid-pull-request
+      params:
+        path: src
+        status: failure
+  - <<: *send-success-status
+    put: cardid-pull-request
+
+- name: pay-direct-debit-connector-test
+  plan:
+  - <<: *pull-request-get
+    resource: direct-debit-connector-pull-request
+  - <<: *send-pending-status
+    put: direct-debit-connector-pull-request
+  - <<: *java-test
+    on_failure:
+      put: direct-debit-connector-pull-request
+      params:
+        path: src
+        status: failure
+  - <<: *send-success-status
+    put: direct-debit-connector-pull-request
+
+- name: ledger-test
+  plan:
+  - <<: *pull-request-get
+    resource: ledger-pull-request
+  - <<: *send-pending-status
+    put: ledger-pull-request
+  - <<: *java-test
+    on_failure:
+      put: ledger-pull-request
+      params:
+        path: src
+        status: failure
+  - <<: *send-success-status
+    put: ledger-pull-request
+
+- name: publicauth-test
+  plan:
+  - <<: *pull-request-get
+    resource: publicauth-pull-request
+  - <<: *send-pending-status
+    put: publicauth-pull-request
+  - <<: *java-test
+    on_failure:
+      put: publicauth-pull-request
+      params:
+        path: src
+        status: failure
+  - <<: *send-success-status
+    put: publicauth-pull-request
+
+- name: publicapi-test
+  plan:
+  - <<: *pull-request-get
+    resource: publicapi-pull-request
+  - <<: *send-pending-status
+    put: publicapi-pull-request
+  - <<: *java-test
+    on_failure:
+      put: publicapi-pull-request
+      params:
+        path: src
+        status: failure
+  - <<: *send-success-status
+    put: publicapi-pull-request

--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -5,27 +5,38 @@ resource_types:
     repository: teliaoss/github-pr-resource
 
 resources:
-  - name: card-connector-pull-request
+  - &pull-request
+    name: card-connector-pull-request
     type: pull-request
     icon: github-cirle
     check_every: 1h
-    source:
+    source: &pull-request-source
       repository: alphagov/pay-connector
       access_token: ((github-access-token))
+
+  - <<: *pull-request
+    name: adminusers-pull-request
+    source:
+      <<: *pull-request-source
+      repository: alphagov/pay-adminusers
+
 
 jobs:
 - name: card-connector-test
   plan:
-  - get: src
+  - &pull-request-get
+    get: src
     resource: card-connector-pull-request
     trigger: true
     version: every
     name: src
-  - put: card-connector-pull-request
+  - &send-pending-status
+    put: card-connector-pull-request
     params:
       path: src
       status: pending
-  - task: test
+  - &java-test
+    task: test
     privileged: true
     config:
       container_limits: {}
@@ -69,7 +80,23 @@ jobs:
       params:
         path: src
         status: failure
-  - put: card-connector-pull-request
+  - &send-success-status
+    put: card-connector-pull-request
     params:
       path: src
       status: success
+
+- name: adminusers-test
+  plan:
+  - <<: *pull-request-get
+    resource: adminusers-pull-request
+  - <<: *send-pending-status
+    put: adminusers-pull-request
+  - <<: *java-test
+    on_failure:
+      put: adminusers-pull-request
+      params:
+        path: src
+        status: failure
+  - <<: *send-success-status
+    put: adminusers-pull-request

--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -31,7 +31,7 @@ resources:
     source:
       <<: *pull-request-source
       repository: alphagov/pay-ledger
-  
+
   - <<: *pull-request
     name: publicauth-pull-request
     source:
@@ -50,6 +50,11 @@ resources:
       <<: *pull-request-source
       repository: alphagov/pay-direct-debit-connector
 
+  - <<: *pull-request
+    name: frontend-pull-request
+    source:
+      <<: *pull-request-source
+      repository: alphagov/pay-frontend
 jobs:
 - name: card-connector-test
   plan:
@@ -204,3 +209,50 @@ jobs:
         status: failure
   - <<: *send-success-status
     put: publicapi-pull-request
+
+- name: frontend-test
+  plan:
+  - <<: *pull-request-get
+    resource: frontend-pull-request
+  - <<: *send-pending-status
+    put: frontend-pull-request
+  - &node-test
+    task: test
+    privileged: true
+    config:
+      platform: linux
+
+      image_resource:
+        type: docker-image
+        source:
+          repository: node
+          tag: 12-alpine
+
+      inputs:
+        - name: src
+
+      caches:
+        - path: src/node_modules
+
+      run:
+        path: sh
+        dir: src
+        args:
+          - -ec
+          - |
+            set -o errexit -o nounset -o pipefail
+            node --version
+            npm --version
+            apk add --virtual build-dependencies --update python build-base libexecinfo-dev ruby
+            npm config set cache ../npm_cache
+            npm rebuild node-sass
+            npm install
+            npm run compile
+            npm test -- --forbid-only --forbid-pending
+    on_failure:
+      put: frontend-pull-request
+      params:
+        path: src
+        status: failure
+  - <<: *send-success-status
+    put: frontend-pull-request

--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -1,0 +1,48 @@
+resource_types:
+- name: pull-request
+  type: docker-image
+  source:
+    repository: teliaoss/github-pr-resource
+
+resources:
+  - name: card-connector-pull-request
+    type: pull-request
+    icon: github-cirle
+    check_every: 1h
+    source:
+      repository: alphagov/pay-connector
+      access_token: ((github-access-token))
+
+jobs:
+- name: card-connector-test
+  plan:
+  - get: card-connector-pull-request
+    trigger: true
+    version: every
+  - put: card-connector-pull-request
+    params:
+      path: card-connector-pull-request
+      status: pending
+  - task: unit-test
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source: {repository: maven, tag: "latest"}
+      inputs:
+        - name: card-connector-pull-request
+      run:
+        path: /bin/sh
+        args:
+          - -xce
+          - |
+            echo "HELLO"
+    on_failure:
+      put: card-connector-pull-request
+      params:
+        path: card-connector-pull-request
+        status: failure
+  - put: card-connector-pull-request
+    params:
+      path: card-connector-pull-request
+      status: success

--- a/ci/tasks/java-tests.yml
+++ b/ci/tasks/java-tests.yml
@@ -1,0 +1,40 @@
+container_limits: {}
+platform: linux
+
+image_resource:
+  type: registry-image
+  source:
+    repository: amidos/dcind
+
+caches:
+  - path: src/.m2
+
+inputs:
+  - name: src
+
+run:
+  path: bash
+  args:
+  - -ec
+  - |
+    apk --no-cache add openjdk11 maven --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community
+
+    source /docker-lib.sh
+    start_docker
+
+    cd src
+
+    export MAVEN_HOME=/usr/lib/mvn
+    export PATH=$MAVEN_HOME/bin:$PATH
+    export MAVEN_REPO="$PWD/.m2"
+
+    cat <<'EOF' >settings.xml
+    <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                              https://maven.apache.org/xsd/settings-1.0.0.xsd">
+          <localRepository>${env.MAVEN_REPO}</localRepository>
+    </settings>
+    EOF
+
+    mvn --global-settings settings.xml clean verify


### PR DESCRIPTION
**What is it?**
Adds a new pipeline for testing pull requests on all application repositories.

Uses the [pull request Concourse resource](https://github.com/telia-oss/github-pr-resource) to run unit and integration tests on Github PRs.

Java builds use a docker-in-docker container environment to allow Java Test Containers to pull and start Postgres and other Docker test dependencies within the test environment.

Within the pr.yml, the first PR build job definition specifies global `max_in_flight` (3 per repo) and `build_log_retention` (500 builds) parameters. These are inherited by all jobs but can be changed or overridden by subsequent job definitions as required.
