### PR TITLE
Add concourse-runner image to run Pay builds

### DIFF
--- a/ci/docker/concourse-runner/Dockerfile
+++ b/ci/docker/concourse-runner/Dockerfile
@@ -1,0 +1,21 @@
+FROM docker:19.03
+
+RUN apk add --no-cache \
+  bash \
+  curl \
+  # dockerd dependencies
+  iptables \
+  util-linux
+
+RUN apk add --no-cache \
+  openjdk11 \
+  maven \
+  tini \
+  docker-compose>1.25.4-r1 \
+  --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community
+
+COPY ./docker-helpers.sh /
+COPY ./docker-wrapper /usr/local/bin/
+
+ENTRYPOINT [ "docker-wrapper" ]
+CMD "ash"

--- a/ci/docker/concourse-runner/README.md
+++ b/ci/docker/concourse-runner/README.md
@@ -1,0 +1,81 @@
+# Pay Concourse Runner
+
+This Docker image is used as an environment to build and run
+Pay application tests on Concourse CI.
+
+Pay application tests require external Docker image dependencies,
+this environment uses Docker-in-Docker to support this on
+Concourse.
+
+The container entrypoint configures a lightweight init script
+(via Tini) to manage the running process. This ensures that
+process signals are interpreted correctly and any running
+Docker containers are correctly cleaned up before exiting.
+
+## Loading external Docker images
+
+If your test environment requires external docker image dependencies,
+these can be loaded as task *inputs* using the Concourse `registry-image`
+resource and using the `oci` image format. This will ensure the
+Concourse resource cache is used between job runs.
+
+See: https://github.com/concourse/registry-image-resource#behavior
+
+Oci images may be loaded by the Docker daemon using `docker load`
+
+# Example Pipeline:
+
+```yml
+resources:
+  - name: postgres
+    type: registry-image
+    source:
+      repository: postgres/11.1
+
+jobs:
+  - name: test
+    plan:
+      - get: docker/postgres
+        resource: postgres
+        params:
+          format: oci
+      - task:
+        privileged: true
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: govukpay/concourse-runner
+            inputs:
+              - name: docker/postgres
+          run:
+            path: bash
+            args:
+              - -ec
+              - |
+                ls -la
+                
+                source /docker-lib.sh
+                start_docker
+
+                echo "Loading Docker images..."
+                pids=
+                index=0
+                for image_dir in docker/*/; do
+                  docker load -qi "${image_dir}image.tar" & pids[${index}]=$!
+                  index="$(( "${index}" + 1 ))"
+                done
+                for pid in ${pids[*]}; do
+                  wait "$pid"
+                done
+
+                # run your task requiring docker or docker-compose here
+                docker images
+```
+
+## Further information
+
+For more information see the following resources:
+ - https://github.com/meAmidos/dcind
+ - https://github.com/krallin/tini

--- a/ci/docker/concourse-runner/docker-helpers.sh
+++ b/ci/docker/concourse-runner/docker-helpers.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+# Based on https://github.com/concourse/docker-image-resource/blob/master/assets/common.sh
+# See https://github.com/meAmidos/dcind
+
+LOG_FILE=${LOG_FILE:-/tmp/docker.log}
+SKIP_PRIVILEGED=${SKIP_PRIVILEGED:-false}
+STARTUP_TIMEOUT=${STARTUP_TIMEOUT:-20}
+
+sanitize_cgroups() {
+  mkdir -p /sys/fs/cgroup
+  mountpoint -q /sys/fs/cgroup || \
+    mount -t tmpfs -o uid=0,gid=0,mode=0755 cgroup /sys/fs/cgroup
+
+  mount -o remount,rw /sys/fs/cgroup
+
+  sed -e 1d /proc/cgroups | while read sys hierarchy num enabled; do
+    if [ "$enabled" != "1" ]; then
+      # subsystem disabled; skip
+      continue
+    fi
+
+    grouping="$(cat /proc/self/cgroup | cut -d: -f2 | grep "\\<$sys\\>")" || true
+    if [ -z "$grouping" ]; then
+      # subsystem not mounted anywhere; mount it on its own
+      grouping="$sys"
+    fi
+
+    mountpoint="/sys/fs/cgroup/$grouping"
+
+    mkdir -p "$mountpoint"
+
+    # clear out existing mount to make sure new one is read-write
+    if mountpoint -q "$mountpoint"; then
+      umount "$mountpoint"
+    fi
+
+    mount -n -t cgroup -o "$grouping" cgroup "$mountpoint"
+
+    if [ "$grouping" != "$sys" ]; then
+      if [ -L "/sys/fs/cgroup/$sys" ]; then
+        rm "/sys/fs/cgroup/$sys"
+      fi
+
+      ln -s "$mountpoint" "/sys/fs/cgroup/$sys"
+    fi
+  done
+
+  if ! test -e /sys/fs/cgroup/systemd ; then
+    mkdir /sys/fs/cgroup/systemd
+    mount -t cgroup -o none,name=systemd none /sys/fs/cgroup/systemd
+  fi
+}
+
+start_docker() {
+  echo "Starting Docker..."
+
+  if [ -f /tmp/docker.pid ]; then
+    echo "Docker is already running"
+    return
+  fi
+
+  mkdir -p /var/log
+  mkdir -p /var/run
+
+  if [ "$SKIP_PRIVILEGED" = "false" ]; then
+    sanitize_cgroups
+
+    # check for /proc/sys being mounted readonly, as systemd does
+    if grep '/proc/sys\s\+\w\+\s\+ro,' /proc/mounts >/dev/null; then
+      mount -o remount,rw /proc/sys
+    fi
+  fi
+
+  local mtu=$(cat /sys/class/net/$(ip route get 8.8.8.8|awk '{ print $5 }')/mtu)
+  local server_args="--mtu ${mtu}"
+  local registry=""
+
+  for registry in $1; do
+    server_args="${server_args} --insecure-registry ${registry}"
+  done
+
+  if [ -n "$2" ]; then
+    server_args="${server_args} --registry-mirror $2"
+  fi
+
+  export server_args LOG_FILE
+
+  try_start() {
+    dockerd --data-root /scratch/docker ${server_args} >$LOG_FILE 2>&1 &
+    echo $! > /tmp/docker.pid
+
+    sleep 1
+
+    echo waiting for docker to come up...
+    until docker info >/dev/null 2>&1; do
+      sleep 1
+      if ! kill -0 "$(cat /tmp/docker.pid)" 2>/dev/null; then
+        return 1
+      fi
+    done
+  }
+
+  if [ "$(command -v declare)" ]; then
+    declare -fx try_start
+
+    if ! timeout ${STARTUP_TIMEOUT} bash -ce 'while true; do try_start && break; done'; then
+      echo Docker failed to start within ${STARTUP_TIMEOUT} seconds.
+      return 1
+    fi
+  else
+    try_start
+  fi
+}
+
+stop_docker() {
+  echo "Stopping Docker..."
+
+  if [ ! -f /tmp/docker.pid ]; then
+    return 0
+  fi
+
+  local pid=$(cat /tmp/docker.pid)
+  if [ -z "$pid" ]; then
+    return 0
+  fi
+
+  kill -TERM $pid
+  rm /tmp/docker.pid
+}
+
+clean_docker() {
+  [[ ! -f /tmp/docker.pid ]] && return 0;
+  echo "cleaning up docker"
+  docker system prune -af --volumes >/dev/null 2>&1 || true
+}

--- a/ci/docker/concourse-runner/docker-wrapper
+++ b/ci/docker/concourse-runner/docker-wrapper
@@ -1,0 +1,16 @@
+#!/sbin/tini /bin/bash
+
+{
+  . /docker-helpers.sh
+  function cleanup_docker() {
+    # prune docker data to work around garbage collection not being consistent
+    clean_docker || true
+    # explicitly kill docker in our own special way defined in docker-helpers,
+    # instead of using dumb-init to propagate different signals up
+    stop_docker || true
+  }
+  trap cleanup_docker EXIT
+}
+
+# This deliberately doesn't use 'exec', as this will prevent the above signal handling from working
+"$@"

--- a/ci/pipelines/concourse-runner.yml
+++ b/ci/pipelines/concourse-runner.yml
@@ -1,0 +1,43 @@
+---
+resources:
+  - name: concourse-runner-src
+    type: git
+    icon: github-circle
+    source:
+      uri: https://github.com/alphagov/pay-omnibus
+      branch: develop
+      paths:
+        - ci/docker/concourse-runner/*
+
+  - name: concourse-runner
+    type: registry-image
+    icon: docker
+    source:
+      repository: govukpay/concourse-runner
+      username: ((docker-username))
+      password: ((docker-password))
+      tag: latest
+
+# Builds and pushes the concourse-runner Docker image used by various Concourse CI pipelines
+jobs:
+  - name: build-and-push
+    plan:
+      - get: concourse-runner-src
+        trigger: true
+      - task: build
+        privileged: true
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: vito/oci-build-task
+          inputs:
+          - name: concourse-runner-src
+            path: .
+          outputs:
+          - name: image
+          run:
+            path: build
+      - put: concourse-runner
+        params: {image: image/image.tar}

--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -5,6 +5,15 @@ resource_types:
     repository: teliaoss/github-pr-resource
 
 resources:
+  - name: pr-ci-pipeline
+    type: git
+    icon: github-circle
+    source:
+      uri: https://github.com/alphagov/pay-omnibus
+      branch: develop
+      paths:
+        - ci/pipelines/pr.yml
+
   - &pull-request
     name: card-connector-pull-request
     type: pull-request
@@ -100,7 +109,8 @@ jobs:
       image_resource:
         type: registry-image
         source:
-          repository: amidos/dcind
+          repository: govukpay/concourse-runner
+          tag: latest
       caches:
         - path: src/.m2
       inputs:
@@ -111,9 +121,7 @@ jobs:
         args:
         - -ec
         - |
-          apk --no-cache add openjdk11 maven --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community
-
-          source /docker-lib.sh
+          source /docker-helpers.sh
           start_docker
 
           cd src
@@ -340,3 +348,10 @@ jobs:
         status: failure
   - <<: *send-success-status
     put: dd-frontend-pull-request
+
+- name: update-pr-ci-pipeline
+  plan:
+    - get: pr-ci-pipeline
+      trigger: true
+    - set_pipeline: pr-ci
+      file: pr-ci-pipeline/ci/pipelines/pr.yml


### PR DESCRIPTION
Adds a Docker image used as an environment to run jobs requiring Docker-in-Docker with extra dependencies preinstalled, such as maven and openjdk11.

Adds readme.md with usage instructions.
Adds concourse pipeline to build and push image to https://hub.docker.com/repository/docker/govukpay/concourse-runner
