### PR TITLE
BAU: Clone cardid-data submodule for cardid PR builds

### DIFF
--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -1,8 +1,9 @@
 resource_types:
 - name: pull-request
-  type: docker-image
+  type: registry-image
   source:
     repository: teliaoss/github-pr-resource
+    tag: dev
 
 resources:
   - name: pr-ci-pipeline
@@ -171,6 +172,8 @@ jobs:
   name: cardid-test
   plan:
   - <<: *pull-request-get
+    params:
+      submodules: true
     resource: cardid-pull-request
   - <<: *send-pending-status
     put: cardid-pull-request


### PR DESCRIPTION
Submodule support has * just * been added to the Concourse PR resource. This allows submodules to be automatically cloned. It's not released yet, so this PR uses a dev image of the pr resource container. It's likely to be released imminently.

This PR enables the submodules parameter when cloning cardid so that cardid-data is also present.

This could also be solved by checking out cardid-data as a separate task input and moving it to the relevant directory.

Uses the `registry-image` resource type, since docker-image is now deprecated.