### PR TITLE
PP-6109: Add Publicapi WAF ACL config

### DIFF
--- a/terraform/modules/aws/publicapi.tf
+++ b/terraform/modules/aws/publicapi.tf
@@ -69,3 +69,9 @@ resource "aws_cloudfront_distribution" "publicapi" {
     ssl_support_method       = "sni-only"
   }
 }
+
+module waf_v2_acl {
+  source      = "./waf_v2_acl" 
+  name        = "publicapi-${var.environment}"
+  description = "Publicapi ACL ${var.environment}"
+}

--- a/terraform/modules/aws/publicapi.tf
+++ b/terraform/modules/aws/publicapi.tf
@@ -68,9 +68,11 @@ resource "aws_cloudfront_distribution" "publicapi" {
     minimum_protocol_version = "TLSv1.2_2018"
     ssl_support_method       = "sni-only"
   }
+
+  web_acl_id = module.publicapi_waf_acl.acl_id
 }
 
-module waf_v2_acl {
+module publicapi_waf_acl {
   source      = "./waf_v2_acl" 
   name        = "publicapi-${var.environment}"
   description = "Publicapi ACL ${var.environment}"

--- a/terraform/modules/aws/waf_v2_acl/configure_aws_wafv2.rb
+++ b/terraform/modules/aws/waf_v2_acl/configure_aws_wafv2.rb
@@ -1,0 +1,41 @@
+#!/usr/bin/env ruby
+
+require 'json'
+require 'logger'
+
+def create_acl!(name, description, rules)
+  out = `aws wafv2 create-web-acl \
+        --scope CLOUDFRONT \
+        --region us-east-1 \
+        --name '#{name}' \
+        --description '#{description}' \
+        --default-action Allow={} \
+        --visibility-config SampledRequestsEnabled=true,CloudWatchMetricsEnabled=false,MetricName=#{name}AclMetrics \
+        --rules '#{rules}'`
+  JSON.load(out).fetch('Summary').fetch('Id')
+end
+
+def wafv2_acl_id(name)
+  JSON.load(`aws wafv2 list-web-acls --scope CLOUDFRONT --region us-east-1`)
+    .dig('WebACLs')
+    &.find { |acl| acl['Name'] == name }
+    &.fetch('ARN')
+end
+
+LOG = Logger.new(STDERR)
+
+query = JSON.load(STDIN.read)
+acl_name = query.fetch('name')
+
+LOG.info("acl_name = #{acl_name}")
+acl_id = wafv2_acl_id(acl_name)
+LOG.info("acl_id = #{acl_id}")
+
+if acl_id.nil?
+  rules = query.fetch('rules')
+  description = query.fetch('description') || ""
+  acl_id = create_acl!(acl_name, description, rules)
+end
+
+result = { 'id' => acl_id }
+puts JSON.dump(result)

--- a/terraform/modules/aws/waf_v2_acl/main.tf
+++ b/terraform/modules/aws/waf_v2_acl/main.tf
@@ -1,0 +1,13 @@
+provider "aws" {
+  alias = "us"
+}
+
+data "external" "aws_waf_v2_acl" {
+  program = ["ruby", "${path.module}/configure_aws_wafv2.rb"]
+
+  query = {
+    name = var.name
+    description = var.description
+    rules = templatefile("${path.module}/rules.tpl", {})
+  }
+}

--- a/terraform/modules/aws/waf_v2_acl/outputs.tf
+++ b/terraform/modules/aws/waf_v2_acl/outputs.tf
@@ -1,0 +1,3 @@
+output "acl_id" {
+  value = data.external.aws_waf_v2_acl.result["id"]
+}

--- a/terraform/modules/aws/waf_v2_acl/rules.tpl
+++ b/terraform/modules/aws/waf_v2_acl/rules.tpl
@@ -1,0 +1,74 @@
+${jsonencode([
+    {
+      "Name": "AWS-AWSManagedRulesCommonRuleSet",
+      "Priority": 0,
+      "Statement": {
+        "ManagedRuleGroupStatement": {
+          "VendorName": "AWS",
+          "Name": "AWSManagedRulesCommonRuleSet"
+        }
+      },
+      "OverrideAction": {
+        "Count": {}
+      },
+      "VisibilityConfig": {
+        "SampledRequestsEnabled": true,
+        "CloudWatchMetricsEnabled": true,
+        "MetricName": "AWS-AWSManagedRulesCommonRuleSet"
+      }
+    },
+    {
+      "Name": "AWS-AWSManagedRulesSQLiRuleSet",
+      "Priority": 1,
+      "Statement": {
+        "ManagedRuleGroupStatement": {
+          "VendorName": "AWS",
+          "Name": "AWSManagedRulesSQLiRuleSet"
+        }
+      },
+      "OverrideAction": {
+        "Count": {}
+      },
+      "VisibilityConfig": {
+        "SampledRequestsEnabled": true,
+        "CloudWatchMetricsEnabled": true,
+        "MetricName": "AWS-AWSManagedRulesSQLiRuleSet"
+      }
+    },
+    {
+      "Name": "AWS-AWSManagedRulesLinuxRuleSet",
+      "Priority": 2,
+      "Statement": {
+        "ManagedRuleGroupStatement": {
+          "VendorName": "AWS",
+          "Name": "AWSManagedRulesLinuxRuleSet"
+        }
+      },
+      "OverrideAction": {
+        "Count": {}
+      },
+      "VisibilityConfig": {
+        "SampledRequestsEnabled": true,
+        "CloudWatchMetricsEnabled": true,
+        "MetricName": "AWS-AWSManagedRulesLinuxRuleSet"
+      }
+    },
+    {
+      "Name": "AWS-AWSManagedRulesKnownBadInputsRuleSet",
+      "Priority": 3,
+      "Statement": {
+        "ManagedRuleGroupStatement": {
+          "VendorName": "AWS",
+          "Name": "AWSManagedRulesKnownBadInputsRuleSet"
+        }
+      },
+      "OverrideAction": {
+        "Count": {}
+      },
+      "VisibilityConfig": {
+        "SampledRequestsEnabled": true,
+        "CloudWatchMetricsEnabled": true,
+        "MetricName": "AWS-AWSManagedRulesKnownBadInputsRuleSet"
+      }
+    }
+])}

--- a/terraform/modules/aws/waf_v2_acl/variables.tf
+++ b/terraform/modules/aws/waf_v2_acl/variables.tf
@@ -1,0 +1,10 @@
+variable "name" {
+  type        = string
+  description = "Name of this ACL (for example: my-waf-acl)"
+}
+
+variable "description" {
+  type    = string
+  default = ""
+  description = "Description of this ACL (for example: My WAF ACL)"
+}


### PR DESCRIPTION
### What?
Adds a ruby script to create a basic WAF ACL using the WAFv2 API.
The ACL uses a JSON template to configure AWS managed rulesets (a new feature in WAFv2).
Composed into a Terrafrom module so it can be applied to other CloudFront distributions.

### How to test?
 - Run `terraform apply` in the aws staging environment
 - Check ACL and resource association in AWS console. Be sure to select *global* region to see ACLs applied to CloudFront distributions.
 - Matching rules are currently set to *count* not *block*, so we can measure stats.
 - The resource does not currently support updating WAF rule template in place.

The Terraform resource to support WAFv2 is due to be merged into the AWS provider.

See: https://github.com/terraform-providers/terraform-provider-aws/pull/12688

Co-authored-by: @rorymalcolm 