### PR TITLE
Refactor WAF provisioning script

### DIFF
--- a/terraform/modules/aws/waf_v2_acl/configure_aws_wafv2.rb
+++ b/terraform/modules/aws/waf_v2_acl/configure_aws_wafv2.rb
@@ -66,15 +66,15 @@ options = {}
 OptionParser.new do |opts|
   opts.banner = "Usage: example.rb [options]"
 
-  opts.on("-n", "--name", "ACL name") do |n|
+  opts.on("--name NAME", "ACL name") do |n|
     options[:name] = n
   end
 
-  opts.on("-d", "--description", "ACL description") do |d|
+  opts.on("--description DESCRIPTION", "ACL description") do |d|
     options[:description] = d
   end
 
-  opts.on("-a", "--acl", "ACL JSON") do |a|
+  opts.on("--acl ACL", "ACL JSON") do |a|
     options[:acl] = a
   end
 end.parse!
@@ -91,9 +91,9 @@ end
 if command == "configure"
   acl_id = wafv2_acl_id(options["name"])
   if acl_id.nil?
-    acl_id = create_acl!(options["name"], options["description", options["acl"])
+    acl_id = create_acl!(options["name"], options["description"], options["acl"])
   else
-    update_acl!(options["name"], options["description", options["acl"])
+    update_acl!(options["name"], options["description"], options["acl"])
   end
 end
 

--- a/terraform/modules/aws/waf_v2_acl/configure_aws_wafv2.rb
+++ b/terraform/modules/aws/waf_v2_acl/configure_aws_wafv2.rb
@@ -2,6 +2,7 @@
 
 require 'json'
 require 'logger'
+require 'optparse'
 
 def create_acl!(name, description, rules)
   out = `aws wafv2 create-web-acl \
@@ -15,6 +16,43 @@ def create_acl!(name, description, rules)
   JSON.load(out).fetch('Summary').fetch('Id')
 end
 
+def update_acl!(name, description, rules)
+  acl = JSON.load(`aws wafv2 list-web-acls --scope CLOUDFRONT --region us-east-1`)
+    .dig('WebACLs')
+    &.find { |acl| acl['Name'] == name }
+
+  acl_id = acl.fetch('Id')
+  lock_token = acl.fetch('LockToken')
+
+  out = `aws wafv2 update-web-acl \
+        --scope CLOUDFRONT \
+        --region us-east-1 \
+        --name '#{name}' \
+        --description '#{description}' \
+        --default-action Allow={} \
+        --visibility-config SampledRequestsEnabled=true,CloudWatchMetricsEnabled=false,MetricName=#{name}AclMetrics \
+        --rules '#{rules}' \
+        --id '#{acl_id}' \
+        --lock-token '#{lock_token}'`
+
+  JSON.load(out).fetch('NextLockToken')
+end
+
+def destroy_acl!(name)
+  acl = JSON.load(`aws wafv2 list-web-acls --scope CLOUDFRONT --region us-east-1`)
+    .dig('WebACLs')
+    &.find { |acl| acl['Name'] == name }
+  
+  acl_id = acl.fetch('Id')
+  lock_token = acl.fetch('LockToken')
+
+  out = `aws wafv2 delete-web-acl \
+        --name '#{name}' \
+        --scope CLOUDFRONT \
+        --id '#{acl_id}' \
+        --lock-token '#{lock_token}'`
+end
+
 def wafv2_acl_id(name)
   JSON.load(`aws wafv2 list-web-acls --scope CLOUDFRONT --region us-east-1`)
     .dig('WebACLs')
@@ -24,18 +62,42 @@ end
 
 LOG = Logger.new(STDERR)
 
-query = JSON.load(STDIN.read)
-acl_name = query.fetch('name')
+options = {}
+OptionParser.new do |opts|
+  opts.banner = "Usage: example.rb [options]"
 
-LOG.info("acl_name = #{acl_name}")
-acl_id = wafv2_acl_id(acl_name)
-LOG.info("acl_id = #{acl_id}")
+  opts.on("-n", "--name", "ACL name") do |n|
+    options[:name] = n
+  end
 
-if acl_id.nil?
-  rules = query.fetch('rules')
-  description = query.fetch('description') || ""
-  acl_id = create_acl!(acl_name, description, rules)
+  opts.on("-d", "--description", "ACL description") do |d|
+    options[:description] = d
+  end
+
+  opts.on("-a", "--acl", "ACL JSON") do |a|
+    options[:acl] = a
+  end
+end.parse!
+
+command = ARGV.pop
+
+raise "Specify command (fetch, configure, destroy)" unless command
+
+if command == "fetch"
+  acl_id = wafv2_acl_id(options["name"])
+  puts JSON.dump({ 'id' => acl_id })
 end
 
-result = { 'id' => acl_id }
-puts JSON.dump(result)
+if command == "configure"
+  acl_id = wafv2_acl_id(options["name"])
+  if acl_id.nil?
+    acl_id = create_acl!(options["name"], options["description", options["acl"])
+  else
+    update_acl!(options["name"], options["description", options["acl"])
+  end
+end
+
+if command == "destroy"
+  LOG.info("Destroying ACL = #{options["name"]}")
+  destroy_acl!(options["name"])
+end

--- a/terraform/modules/aws/waf_v2_acl/configure_aws_wafv2.rb
+++ b/terraform/modules/aws/waf_v2_acl/configure_aws_wafv2.rb
@@ -56,7 +56,7 @@ end
 def wafv2_acl_id(name)
   JSON.load(`aws wafv2 list-web-acls --scope CLOUDFRONT --region us-east-1`)
     .dig('WebACLs')
-    &.find { |acl| acl['Name'] == name }
+    &.find { |item| item['Name'] == name }
     &.fetch('ARN')
 end
 
@@ -84,20 +84,20 @@ command = ARGV.pop
 raise "Specify command (fetch, configure, destroy)" unless command
 
 if command == "fetch"
-  acl_id = wafv2_acl_id(options["name"])
+  acl_id = wafv2_acl_id(options[:name])
   puts JSON.dump({ 'id' => acl_id })
 end
 
 if command == "configure"
-  acl_id = wafv2_acl_id(options["name"])
+  acl_id = wafv2_acl_id(options[:name])
   if acl_id.nil?
-    acl_id = create_acl!(options["name"], options["description"], options["acl"])
+    acl_id = create_acl!(options[:name], options[:description], options[:acl])
   else
-    update_acl!(options["name"], options["description"], options["acl"])
+    update_acl!(options[:name], options[:description], options[:acl])
   end
 end
 
 if command == "destroy"
-  LOG.info("Destroying ACL = #{options["name"]}")
-  destroy_acl!(options["name"])
+  LOG.info("Destroying ACL = #{options[:name]}")
+  destroy_acl!(options[:name])
 end

--- a/terraform/modules/aws/waf_v2_acl/fetch_aws_wafv2.rb
+++ b/terraform/modules/aws/waf_v2_acl/fetch_aws_wafv2.rb
@@ -1,0 +1,24 @@
+#!/usr/bin/env ruby
+
+require 'json'
+require 'logger'
+
+def wafv2_acl_id(name)
+  JSON.load(`aws wafv2 list-web-acls --scope CLOUDFRONT --region us-east-1`)
+    .dig('WebACLs')
+    &.find { |acl| acl['Name'] == name }
+    &.fetch('ARN')
+end
+
+LOG = Logger.new(STDERR)
+
+query = JSON.load(STDIN.read)
+acl_name = query.fetch('name')
+
+LOG.info("acl_name = #{acl_name}")
+acl_id = wafv2_acl_id(acl_name)
+LOG.info("acl_id = #{acl_id}")
+
+result = { 'id' => acl_id }
+puts JSON.dump(result)
+

--- a/terraform/modules/aws/waf_v2_acl/main.tf
+++ b/terraform/modules/aws/waf_v2_acl/main.tf
@@ -3,7 +3,11 @@ locals {
 }
 
 data "external" "aws_waf_v2_acl" {
-  program = ["ruby", "${path.module}/configure_aws_wafv2.rb fetch --name ${var.name}"]
+  program = ["ruby", "${path.module}/fetch_aws_wafv2.rb"]
+
+  query = {
+    name = var.name
+  }
 }
 
 resource "null_resource" "aws_waf_v2_acl" {
@@ -14,7 +18,7 @@ resource "null_resource" "aws_waf_v2_acl" {
   }
 
   provisioner "local-exec" {
-    command = "${path.module}/configure_aws_wafv2.rb configure --name ${self.triggers.name} --description ${self.triggers.description} --acl ${self.triggers.acl_rules}"
+    command = "${path.module}/configure_aws_wafv2.rb configure --name ${self.triggers.name} --description ${self.triggers.description} --acl '${self.triggers.acl_rules}'"
   }
 
   provisioner "local-exec" {

--- a/terraform/modules/aws/waf_v2_acl/main.tf
+++ b/terraform/modules/aws/waf_v2_acl/main.tf
@@ -12,17 +12,12 @@ data "external" "aws_waf_v2_acl" {
 
 resource "null_resource" "aws_waf_v2_acl" {
   triggers = {
-     name       = var.name
+    name        = var.name
     description = var.description
     acl_rules   = local.acl_rules
   }
 
   provisioner "local-exec" {
     command = "${path.module}/configure_aws_wafv2.rb configure --name ${self.triggers.name} --description ${self.triggers.description} --acl '${self.triggers.acl_rules}'"
-  }
-
-  provisioner "local-exec" {
-    when    = destroy
-    command = "${path.module}/configure_aws_wafv2.rb destroy --name ${self.triggers.name}"
   }
 }

--- a/terraform/modules/aws/waf_v2_acl/rules.tpl
+++ b/terraform/modules/aws/waf_v2_acl/rules.tpl
@@ -45,7 +45,7 @@ ${jsonencode([
         }
       },
       "OverrideAction": {
-        "Block": {}
+        "Count": {}
       },
       "VisibilityConfig": {
         "SampledRequestsEnabled": true,

--- a/terraform/modules/aws/waf_v2_acl/rules.tpl
+++ b/terraform/modules/aws/waf_v2_acl/rules.tpl
@@ -45,7 +45,7 @@ ${jsonencode([
         }
       },
       "OverrideAction": {
-        "Count": {}
+        "Block": {}
       },
       "VisibilityConfig": {
         "SampledRequestsEnabled": true,


### PR DESCRIPTION
Adds a Terraform `null_resource` with script to provision a WAF v2 ACL. This allows updates to the resource to be triggered by changes to the ACL rule configuration.

When a change occurs this will trigger the null_resource to be recreated. However, the script that is executed ensures that any existing WAF is updated instead of being destroyed and recreated.