### PR TITLE
PP-6447: Attach WAF ACLs to public Cloudfront distributions

### DIFF
--- a/terraform/modules/aws/card-frontend.tf
+++ b/terraform/modules/aws/card-frontend.tf
@@ -70,6 +70,8 @@ resource "aws_cloudfront_distribution" "card_frontend" {
     minimum_protocol_version = "TLSv1.2_2018"
     ssl_support_method       = "sni-only"
   }
+
+  web_acl_id = module.card_frontend_waf_acl.acl_id
 }
 
 data "pass_password" "card_frontend_pubkey" {

--- a/terraform/modules/aws/directdebit-frontend.tf
+++ b/terraform/modules/aws/directdebit-frontend.tf
@@ -68,6 +68,8 @@ resource "aws_cloudfront_distribution" "directdebit_frontend" {
     minimum_protocol_version = "TLSv1.2_2018"
     ssl_support_method       = "sni-only"
   }
+
+  web_acl_id = module.direct_debit_frontend_waf_acl.acl_id
 }
 
 module direct_debit_frontend_waf_acl {

--- a/terraform/modules/aws/notifications.tf
+++ b/terraform/modules/aws/notifications.tf
@@ -68,6 +68,8 @@ resource "aws_cloudfront_distribution" "notifications" {
     minimum_protocol_version = "TLSv1.2_2018"
     ssl_support_method       = "sni-only"
   }
+
+  web_acl_id = module.notifications_waf_acl.acl_id
 }
 
 module notifications_waf_acl {

--- a/terraform/modules/aws/products-ui.tf
+++ b/terraform/modules/aws/products-ui.tf
@@ -68,6 +68,8 @@ resource "aws_cloudfront_distribution" "products_ui" {
     minimum_protocol_version = "TLSv1.2_2018"
     ssl_support_method       = "sni-only"
   }
+
+  web_acl_id = module.products_ui_waf_acl.acl_id
 }
 
 module products_ui_waf_acl {

--- a/terraform/modules/aws/selfservice.tf
+++ b/terraform/modules/aws/selfservice.tf
@@ -68,6 +68,8 @@ resource "aws_cloudfront_distribution" "selfservice" {
     minimum_protocol_version = "TLSv1.2_2018"
     ssl_support_method       = "sni-only"
   }
+
+  web_acl_id = module.selfservice_waf_acl.acl_id
 }
 
 module selfservice_waf_acl {


### PR DESCRIPTION
ACLs are created for the respective distributions but must be applied to CloudFront using the id/arn value from the WAFv2 module.

TF has now been applied.