### PR TITLE
PP-6447: Support overriding of WAF ACL configuration

### DIFF
--- a/terraform/modules/aws/publicapi.tf
+++ b/terraform/modules/aws/publicapi.tf
@@ -76,4 +76,85 @@ module publicapi_waf_acl {
   source      = "./waf_v2_acl" 
   name        = "publicapi-${var.environment}"
   description = "Publicapi ACL ${var.environment}"
+  acl         = <<EOF
+[
+    {
+      "Name": "AWS-AWSManagedRulesSQLiRuleSet",
+      "Priority": 0,
+      "Statement": {
+        "ManagedRuleGroupStatement": {
+          "VendorName": "AWS",
+          "Name": "AWSManagedRulesSQLiRuleSet"
+        }
+      },
+      "OverrideAction": {
+        "Count": {}
+      },
+      "VisibilityConfig": {
+        "SampledRequestsEnabled": true,
+        "CloudWatchMetricsEnabled": true,
+        "MetricName": "AWS-AWSManagedRulesSQLiRuleSet"
+      }
+    },
+    {
+      "Name": "AWS-AWSManagedRulesLinuxRuleSet",
+      "Priority": 1,
+      "Statement": {
+        "ManagedRuleGroupStatement": {
+          "VendorName": "AWS",
+          "Name": "AWSManagedRulesLinuxRuleSet"
+        }
+      },
+      "OverrideAction": {
+        "Count": {}
+      },
+      "VisibilityConfig": {
+        "SampledRequestsEnabled": true,
+        "CloudWatchMetricsEnabled": true,
+        "MetricName": "AWS-AWSManagedRulesLinuxRuleSet"
+      }
+    },
+    {
+      "Name": "AWS-AWSManagedRulesKnownBadInputsRuleSet",
+      "Priority": 2,
+      "Statement": {
+        "ManagedRuleGroupStatement": {
+          "VendorName": "AWS",
+          "Name": "AWSManagedRulesKnownBadInputsRuleSet"
+        }
+      },
+      "OverrideAction": {
+        "Count": {}
+      },
+      "VisibilityConfig": {
+        "SampledRequestsEnabled": true,
+        "CloudWatchMetricsEnabled": true,
+        "MetricName": "AWS-AWSManagedRulesKnownBadInputsRuleSet"
+      }
+    },
+    {
+      "Name": "AWS-AWSManagedRulesCommonRuleSet",
+      "Priority": 3,
+      "Statement": {
+        "ManagedRuleGroupStatement": {
+          "VendorName": "AWS",
+          "Name": "AWSManagedRulesCommonRuleSet",
+          "ExcludedRules": [
+            {
+              "Name": "GenericRFI_BODY"
+            }
+          ]
+        }
+      },
+      "OverrideAction": {
+        "None": {}
+      },
+      "VisibilityConfig": {
+        "SampledRequestsEnabled": true,
+        "CloudWatchMetricsEnabled": true,
+        "MetricName": "AWS-AWSManagedRulesCommonRuleSet"
+      }
+    }
+  ]
+EOF
 }

--- a/terraform/modules/aws/waf_v2_acl/main.tf
+++ b/terraform/modules/aws/waf_v2_acl/main.tf
@@ -14,7 +14,7 @@ resource "null_resource" "aws_waf_v2_acl" {
   triggers = {
     name        = var.name
     description = "'${var.description}'"
-    acl_rules   = local.acl_rules
+    acl_rules   = var.acl != null ? var.acl : local.acl_rules
   }
 
   provisioner "local-exec" {

--- a/terraform/modules/aws/waf_v2_acl/variables.tf
+++ b/terraform/modules/aws/waf_v2_acl/variables.tf
@@ -4,7 +4,13 @@ variable "name" {
 }
 
 variable "description" {
-  type    = string
-  default = ""
+  type        = string
+  default     = ""
   description = "Description of this ACL (for example: My WAF ACL)"
+}
+
+variable "acl" {
+  type        = string
+  default     = null
+  description = "Optional JSON ACL config"
 }


### PR DESCRIPTION
Allows optional override of ACL rules for CloudFront distributions. This allows individual endpoints to adjust ACL rules as required.

Co-authored-by: @rorymalcolm 