### PR TITLE
PP-6447: Add logging config to WAFv2 terraform

### DIFF
--- a/terraform/modules/aws/publicapi.tf
+++ b/terraform/modules/aws/publicapi.tf
@@ -157,4 +157,15 @@ module publicapi_waf_acl {
     }
   ]
 EOF
+
+  log_destination     = aws_kinesis_firehose_delivery_stream.waf_kinesis_stream.id
+  log_redacted_fields = <<EOF
+[
+  {
+    "SingleHeader": {
+      "Name": "authorization"
+    }
+  }
+]
+EOF
 }

--- a/terraform/modules/aws/waf_v2_acl/configure_aws_wafv2.rb
+++ b/terraform/modules/aws/waf_v2_acl/configure_aws_wafv2.rb
@@ -4,19 +4,25 @@ require 'json'
 require 'logger'
 require 'optparse'
 
-def create_acl!(name, description, rules)
-  out = `aws wafv2 create-web-acl \
+def create_acl!(name, description, rules, log_destination = nil, log_redacted_fields = nil)
+  out = JSON.load(`aws wafv2 create-web-acl \
         --scope CLOUDFRONT \
         --region us-east-1 \
         --name '#{name}' \
         --description '#{description}' \
         --default-action Allow={} \
         --visibility-config SampledRequestsEnabled=true,CloudWatchMetricsEnabled=false,MetricName=#{name}AclMetrics \
-        --rules '#{rules}'`
-  JSON.load(out).fetch('Summary').fetch('Id')
+        --rules '#{rules}'`)
+
+  if log_destination
+    arn = out.fetch('Summary').fetch('ARN')
+    put_log_config!(arn, log_destination, log_redacted_fields)
+  end
+
+  out.fetch('Summary').fetch('Id')
 end
 
-def update_acl!(name, description, rules)
+def update_acl!(name, description, rules, log_destination = nil, log_redacted_fields = nil)
   acl = JSON.load(`aws wafv2 list-web-acls --scope CLOUDFRONT --region us-east-1`)
     .dig('WebACLs')
     &.find { |acl| acl['Name'] == name }
@@ -24,7 +30,7 @@ def update_acl!(name, description, rules)
   acl_id = acl.fetch('Id')
   lock_token = acl.fetch('LockToken')
 
-  out = `aws wafv2 update-web-acl \
+  out = JSON.load(`aws wafv2 update-web-acl \
         --scope CLOUDFRONT \
         --region us-east-1 \
         --name '#{name}' \
@@ -33,9 +39,29 @@ def update_acl!(name, description, rules)
         --visibility-config SampledRequestsEnabled=true,CloudWatchMetricsEnabled=false,MetricName=#{name}AclMetrics \
         --rules '#{rules}' \
         --id '#{acl_id}' \
-        --lock-token '#{lock_token}'`
+        --lock-token '#{lock_token}'`)
 
-  JSON.load(out).fetch('NextLockToken')
+  if log_destination
+    put_log_config!(acl.fetch('ARN'), log_destination, log_redacted_fields)
+  end
+
+  out.fetch('NextLockToken')
+end
+
+def put_log_config!(acl_arn, log_destination, log_redacted_fields)
+  config = {
+    ResourceArn: acl_arn,
+    LogDestinationConfigs: [
+      log_destination
+    ],
+    RedactedFields: log_redacted_fields ? JSON.load(log_redacted_fields) : nil
+  }
+
+  out = `aws wafv2 put-logging-configuration \
+       --logging-configuration '#{config.to_json}' \
+       --region us-east-1`
+
+  JSON.load(out)
 end
 
 def destroy_acl!(name)
@@ -77,6 +103,14 @@ OptionParser.new do |opts|
   opts.on("--acl ACL", "ACL JSON") do |a|
     options[:acl] = a
   end
+
+  opts.on("--log-destination DESTINATION", "Log destination") do |ld|
+    options[:log_destination] = ld
+  end
+
+  opts.on("--log-redacted-fields FIELDS", "Log redacted fields") do |rf|
+    options[:log_redacted_fields] = rf
+  end
 end.parse!
 
 command = ARGV.pop
@@ -91,9 +125,9 @@ end
 if command == "configure"
   acl_id = wafv2_acl_id(options[:name])
   if acl_id.nil?
-    acl_id = create_acl!(options[:name], options[:description], options[:acl])
+    acl_id = create_acl!(options[:name], options[:description], options[:acl], options[:log_destination], options[:log_redacted_fields])
   else
-    update_acl!(options[:name], options[:description], options[:acl])
+    update_acl!(options[:name], options[:description], options[:acl], options[:log_destination], options[:log_redacted_fields])
   end
 end
 

--- a/terraform/modules/aws/waf_v2_acl/main.tf
+++ b/terraform/modules/aws/waf_v2_acl/main.tf
@@ -12,12 +12,14 @@ data "external" "aws_waf_v2_acl" {
 
 resource "null_resource" "aws_waf_v2_acl" {
   triggers = {
-    name        = var.name
-    description = "'${var.description}'"
-    acl_rules   = var.acl != null ? var.acl : local.acl_rules
+    name                = var.name
+    description         = "'${var.description}'"
+    acl_rules           = var.acl != null ? var.acl : local.acl_rules
+    log_destination     = var.log_destination
+    log_redacted_fields = var.log_redacted_fields
   }
 
   provisioner "local-exec" {
-    command = "${path.module}/configure_aws_wafv2.rb configure --name ${self.triggers.name} --description ${self.triggers.description} --acl '${self.triggers.acl_rules}'"
+    command = "${path.module}/configure_aws_wafv2.rb configure --name ${self.triggers.name} --description ${self.triggers.description} --acl '${self.triggers.acl_rules}' --log-destination ${self.triggers.log_destination} --log-redacted-fields '${self.triggers.log_redacted_fields}'"
   }
 }

--- a/terraform/modules/aws/waf_v2_acl/variables.tf
+++ b/terraform/modules/aws/waf_v2_acl/variables.tf
@@ -14,3 +14,15 @@ variable "acl" {
   default     = null
   description = "Optional JSON ACL config"
 }
+
+variable "log_destination" {
+  type        = string
+  default     = null
+  description = "Optional Kinesis Firehose log destination for this ACL"
+}
+
+variable "log_redacted_fields" {
+  type        = string
+  default     = null
+  description = "Redacted fields config for this ACL"
+}


### PR DESCRIPTION
Allows an optional log_destination and field redaction config
to be passed to a WAF ACL "resource". This allows WAF logs to be
pushed to a kinesis stream.

Public API WAF is configured to redact the Authorization header
so tokens do not appear in any WAF logs.

Co-authored-by: Rory Malcolm <rory.malcolm@digital.cabinet-office.gov.uk>