### PR TITLE
PP-6448: WAF Log Kinesis Firehose Delivery Stream

### DIFF
--- a/lambda/waf-to-splunk-kinesis-data-transformation/.gitingore
+++ b/lambda/waf-to-splunk-kinesis-data-transformation/.gitingore
@@ -1,1 +1,2 @@
 node_modules
+.zip

--- a/lambda/waf-to-splunk-kinesis-data-transformation/index.js
+++ b/lambda/waf-to-splunk-kinesis-data-transformation/index.js
@@ -1,10 +1,13 @@
 exports.handler = async (event, context) => {
     /* Process the list of records and transform them */
+    const okCount = 0
+    const droppedCount = 0
     const output = event.records.map((record) => {
         const eventJson = Buffer.from(record.data, 'base64').toString('utf8')
         const event = JSON.parse(eventJson)
 
         if (event.action === 'ALLOW') {
+            droppedCount++
             return {
                 recordId: record.recordId,
                 result: 'Dropped',
@@ -12,6 +15,7 @@ exports.handler = async (event, context) => {
             };
         }
 
+        okCount++
         const data = {
             time: (event.timestamp / 1000),
             host: "lambda",
@@ -27,6 +31,6 @@ exports.handler = async (event, context) => {
             data: Buffer.from(JSON.stringify(data), 'utf8').toString('base64')
         }
     });
-    console.log(`Processing completed. Successful records ${output.length}.`)
+    console.log(`Processing completed. Successful records ${output.length}. Dropped ${droppedCount}. Ok ${okCount}.`)
     return { records: output };
 };

--- a/lambda/waf-to-splunk-kinesis-data-transformation/index.js
+++ b/lambda/waf-to-splunk-kinesis-data-transformation/index.js
@@ -1,7 +1,7 @@
 exports.handler = async (event, context) => {
     /* Process the list of records and transform them */
-    const okCount = 0
-    const droppedCount = 0
+    let okCount = 0
+    let droppedCount = 0
     const output = event.records.map((record) => {
         const eventJson = Buffer.from(record.data, 'base64').toString('utf8')
         const event = JSON.parse(eventJson)
@@ -31,6 +31,6 @@ exports.handler = async (event, context) => {
             data: Buffer.from(JSON.stringify(data), 'utf8').toString('base64')
         }
     });
-    console.log(`Processing completed. Successful records ${output.length}. Dropped ${droppedCount}. Ok ${okCount}.`)
+    console.log(`Processing completed. Total ${output.length}. Dropped ${droppedCount}. Ok ${okCount}.`)
     return { records: output };
 };

--- a/terraform/modules/aws/logs.tf
+++ b/terraform/modules/aws/logs.tf
@@ -6,4 +6,6 @@ resource "aws_s3_bucket" "cloudfront_logs" {
 module "waf_logging" {
   source = "./waf_logging"
   environment = var.environment
+  splunk_hec_endpoint = var.splunk_hec_endpoint
+  splunk_hec_token = var.splunk_hec_token
 }

--- a/terraform/modules/aws/variables.tf
+++ b/terraform/modules/aws/variables.tf
@@ -12,3 +12,13 @@ variable "paas_domain" {
   type        = string
   description = "PaaS domain for Cloudfront origin"
 }
+
+variable "splunk_hec_token" {
+  type        = string
+  description = "HEC Token for Splunk"
+}
+
+variable "splunk_hec_endpoint" {
+  type        = string
+  description = "HEC Endpoint for Splunk"  
+}

--- a/terraform/modules/aws/waf_logging/kinesis-firehose.tf
+++ b/terraform/modules/aws/waf_logging/kinesis-firehose.tf
@@ -30,4 +30,25 @@ resource "aws_kinesis_firehose_delivery_stream" "waf_kinesis_stream" {
     role_arn           = aws_iam_role.waf_firehose_iam_role.arn
     bucket_arn         = aws_s3_bucket.waf_log_bucket.arn
   }
+
+  splunk_configuration {
+    hec_endpoint               = var.splunk_hec_endpoint
+    hec_token                  = var.splunk_hec_token
+    hec_acknowledgment_timeout = 600
+    hec_endpoint_type          = "Event"
+    s3_backup_mode             = "FailedEventsOnly"
+
+    processing_configuration {
+      enabled = "true"
+
+      processors {
+        type = "Lambda"
+
+        parameters {
+          parameter_name  = "LambdaArn"
+          parameter_value = "${aws_lambda_function.kinesis_data_transformation_lambda.arn}:$LATEST"
+        }
+      }
+    }
+  }
 }

--- a/terraform/modules/aws/waf_logging/kinesis-firehose.tf
+++ b/terraform/modules/aws/waf_logging/kinesis-firehose.tf
@@ -17,19 +17,48 @@ resource "aws_iam_role" "waf_firehose_iam_role" {
 EOF
 }
 
+resource "aws_iam_role_policy" "waf_firehose_s3_policy" {
+    name   = "waf-firehose-s3-policy"
+    role   = aws_iam_role.waf_firehose_iam_role.id
+    policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "",
+            "Effect": "Allow",
+            "Action": [
+                "s3:AbortMultipartUpload",
+                "s3:GetBucketLocation",
+                "s3:GetObject",
+                "s3:ListBucket",
+                "s3:ListBucketMultipartUploads",
+                "s3:PutObject"
+            ],
+            "Resource": [
+                "${aws_s3_bucket.waf_log_bucket.arn}",
+                "${aws_s3_bucket.waf_log_bucket.arn}/*"
+            ]
+        },
+        {
+            "Sid": "",
+            "Effect": "Allow",
+            "Action": [
+                "lambda:InvokeFunction",
+                "lambda:GetFunctionConfiguration"
+            ],
+            "Resource": "${aws_lambda_function.kinesis_data_transformation_lambda.arn}:$LATEST"
+        }
+    ]
+}
+EOF
+}
+
 
 resource "aws_kinesis_firehose_delivery_stream" "waf_kinesis_stream" {
   provider    = aws.us
   name        = "aws-waf-logs-govuk-pay-waf-kinesis-stream-${var.environment}"
-  destination = "s3"
-
-  s3_configuration {
-    buffer_size        = 10
-    buffer_interval    = 400
-    compression_format = "GZIP"
-    role_arn           = aws_iam_role.waf_firehose_iam_role.arn
-    bucket_arn         = aws_s3_bucket.waf_log_bucket.arn
-  }
+  destination = "splunk"
 
   splunk_configuration {
     hec_endpoint               = var.splunk_hec_endpoint
@@ -48,7 +77,30 @@ resource "aws_kinesis_firehose_delivery_stream" "waf_kinesis_stream" {
           parameter_name  = "LambdaArn"
           parameter_value = "${aws_lambda_function.kinesis_data_transformation_lambda.arn}:$LATEST"
         }
+
+        parameters {
+            parameter_name  = "BufferSizeInMBs"
+            parameter_value = 3
+        }
+
+        parameters {
+            parameter_name  = "BufferIntervalInSeconds"
+            parameter_value = 60
+        }
+
+        parameters {
+            parameter_name  = "RoleArn"
+            parameter_value = aws_iam_role.iam_kinesis_data_transformation_lambda.arn
+        }
       }
     }
+  }
+
+  s3_configuration {
+    buffer_size        = 10
+    buffer_interval    = 400
+    compression_format = "GZIP"
+    role_arn           = aws_iam_role.waf_firehose_iam_role.arn
+    bucket_arn         = aws_s3_bucket.waf_log_bucket.arn
   }
 }

--- a/terraform/modules/aws/waf_logging/kinesis-firehose.tf
+++ b/terraform/modules/aws/waf_logging/kinesis-firehose.tf
@@ -1,5 +1,82 @@
-resource "aws_iam_role" "waf_firehose_iam_role" {
-    name = "waf-firehose-iam-role"
+resource "aws_kinesis_firehose_delivery_stream" "waf_kinesis_stream" {
+  provider    = aws.us
+  name        = "aws-waf-logs-govuk-pay-waf-kinesis-stream-${var.environment}"
+  destination = "splunk"
+
+  splunk_configuration {
+    hec_endpoint               = var.splunk_hec_endpoint
+    hec_token                  = var.splunk_hec_token
+    hec_acknowledgment_timeout = 600
+    hec_endpoint_type          = "Event"
+    s3_backup_mode             = "FailedEventsOnly"
+
+    cloudwatch_logging_options {
+      enabled         = true
+      log_group_name  = aws_cloudwatch_log_group.waf_firehose_delivery_stream.name
+      log_stream_name = "SplunkDelivery"
+    }
+
+    processing_configuration {
+      enabled = "true"
+
+      processors {
+        type = "Lambda"
+
+        parameters {     
+            parameter_name  = "LambdaArn"
+            parameter_value = "${aws_lambda_function.kinesis_data_transformation_lambda.arn}:$LATEST"
+        }
+        parameters { 
+            parameter_name  = "BufferSizeInMBs"
+            parameter_value = 3
+        }
+        parameters { 
+            parameter_name  = "BufferIntervalInSeconds"
+            parameter_value = 60
+        }
+        parameters { 
+            parameter_name  = "RoleArn"
+            parameter_value = aws_iam_role.waf_firehose_delivery.arn
+        }
+      }
+    }
+  }
+
+  s3_configuration {
+    buffer_size        = 10
+    buffer_interval    = 400
+    compression_format = "GZIP"
+    role_arn           = aws_iam_role.waf_firehose_delivery.arn
+    bucket_arn         = aws_s3_bucket.waf_log_bucket.arn
+
+    cloudwatch_logging_options {
+      enabled         = true
+      log_group_name  = aws_cloudwatch_log_group.waf_firehose_delivery_stream.name
+      log_stream_name = "S3Delivery"
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_group" "waf_firehose_delivery_stream" {
+  provider          = aws.us
+  name              = "/aws/kinesisfirehose/aws-waf-logs-govuk-pay-waf-kinesis-stream"
+  retention_in_days = 7
+}
+
+resource "aws_cloudwatch_log_stream" "splunk_delivery_stream" {
+  provider       = aws.us
+  name           = "SplunkDelivery"
+  log_group_name = aws_cloudwatch_log_group.waf_firehose_delivery_stream.name
+}
+
+resource "aws_cloudwatch_log_stream" "s3_delivery_stream" {
+  provider       = aws.us
+  name           = "S3Delivery"
+  log_group_name = aws_cloudwatch_log_group.waf_firehose_delivery_stream.name
+}
+
+resource "aws_iam_role" "waf_firehose_delivery" {
+    name = "waf-firehose-delivery-role"
     assume_role_policy = <<EOF
 {
     "Version": "2012-10-17",
@@ -17,9 +94,9 @@ resource "aws_iam_role" "waf_firehose_iam_role" {
 EOF
 }
 
-resource "aws_iam_role_policy" "waf_firehose_s3_policy" {
-    name   = "waf-firehose-s3-policy"
-    role   = aws_iam_role.waf_firehose_iam_role.id
+resource "aws_iam_role_policy" "waf_firehose_delivery" {
+    name   = "waf-firehose-delivery-policy"
+    role   = aws_iam_role.waf_firehose_delivery.id
     policy = <<EOF
 {
     "Version": "2012-10-17",
@@ -48,59 +125,18 @@ resource "aws_iam_role_policy" "waf_firehose_s3_policy" {
                 "lambda:GetFunctionConfiguration"
             ],
             "Resource": "${aws_lambda_function.kinesis_data_transformation_lambda.arn}:$LATEST"
+        },
+        {
+            "Sid": "",
+            "Effect": "Allow",
+            "Action": [
+                "logs:PutLogEvents"
+            ],
+            "Resource": [
+                "${aws_cloudwatch_log_group.waf_firehose_delivery_stream.arn}:*"
+            ]
         }
     ]
 }
 EOF
-}
-
-
-resource "aws_kinesis_firehose_delivery_stream" "waf_kinesis_stream" {
-  provider    = aws.us
-  name        = "aws-waf-logs-govuk-pay-waf-kinesis-stream-${var.environment}"
-  destination = "splunk"
-
-  splunk_configuration {
-    hec_endpoint               = var.splunk_hec_endpoint
-    hec_token                  = var.splunk_hec_token
-    hec_acknowledgment_timeout = 600
-    hec_endpoint_type          = "Event"
-    s3_backup_mode             = "FailedEventsOnly"
-
-    processing_configuration {
-      enabled = "true"
-
-      processors {
-        type = "Lambda"
-
-        parameters {
-          parameter_name  = "LambdaArn"
-          parameter_value = "${aws_lambda_function.kinesis_data_transformation_lambda.arn}:$LATEST"
-        }
-
-        parameters {
-            parameter_name  = "BufferSizeInMBs"
-            parameter_value = 3
-        }
-
-        parameters {
-            parameter_name  = "BufferIntervalInSeconds"
-            parameter_value = 60
-        }
-
-        parameters {
-            parameter_name  = "RoleArn"
-            parameter_value = aws_iam_role.iam_kinesis_data_transformation_lambda.arn
-        }
-      }
-    }
-  }
-
-  s3_configuration {
-    buffer_size        = 10
-    buffer_interval    = 400
-    compression_format = "GZIP"
-    role_arn           = aws_iam_role.waf_firehose_iam_role.arn
-    bucket_arn         = aws_s3_bucket.waf_log_bucket.arn
-  }
 }

--- a/terraform/modules/aws/waf_logging/lambda.tf
+++ b/terraform/modules/aws/waf_logging/lambda.tf
@@ -1,12 +1,38 @@
+locals {
+  lambda_function_name = "waf-kinesis-splunk-transformation"
+}
+
 data "archive_file" "zip_lambda" {
     type        = "zip"
     source_file = "${path.module}/../../../../lambda/waf-to-splunk-kinesis-data-transformation/index.js"
     output_path = "${path.module}/../../../../lambda/waf-to-splunk-kinesis-data-transformation/index.zip"
 }
 
-resource "aws_iam_role" "iam_kinesis_data_transformation_lambda" {
-  name = "iam_kinesis_data_transformation_lambda"
 
+resource "aws_lambda_function" "kinesis_data_transformation_lambda" {
+  provider         = aws.us
+  filename         = data.archive_file.zip_lambda.output_path
+  function_name    = local.lambda_function_name
+  role             = aws_iam_role.iam_kinesis_data_transformation_lambda.arn
+  handler          = "index.handler"
+  description      = "An Amazon Kinesis Firehose stream processor that accesses the records in the input and returns them with a processing status."
+  source_code_hash = data.archive_file.zip_lambda.output_base64sha256
+  runtime          = "nodejs12.x"
+
+  depends_on = [
+    aws_iam_role_policy_attachment.lambda_logs, 
+    aws_cloudwatch_log_group.waf_kinesis_data_transformation_log_group
+  ]
+}
+
+resource "aws_cloudwatch_log_group" "waf_kinesis_data_transformation_log_group" {
+  provider          = aws.us
+  name              = "/aws/lambda/${local.lambda_function_name}"
+  retention_in_days = 7
+}
+
+resource "aws_iam_role" "iam_kinesis_data_transformation_lambda" {
+  name = "${local.lambda_function_name}-role"
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -24,13 +50,7 @@ resource "aws_iam_role" "iam_kinesis_data_transformation_lambda" {
 EOF
 }
 
-resource "aws_lambda_function" "kinesis_data_transformation_lambda" {
-  provider         = aws.us
-  filename         = data.archive_file.zip_lambda.output_path
-  function_name    = "waf-kinesis-splunk-transformation"
-  role             = aws_iam_role.iam_kinesis_data_transformation_lambda.arn
-  handler          = "index.handler"
-  description      = "An Amazon Kinesis Firehose stream processor that accesses the records in the input and returns them with a processing status."
-  source_code_hash = data.archive_file.zip_lambda.output_base64sha256
-  runtime          = "nodejs12.x"
+resource "aws_iam_role_policy_attachment" "lambda_logs" {
+  role       = "${aws_iam_role.iam_kinesis_data_transformation_lambda.name}"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
 }

--- a/terraform/modules/aws/waf_logging/lambda.tf
+++ b/terraform/modules/aws/waf_logging/lambda.tf
@@ -8,7 +8,6 @@ data "archive_file" "zip_lambda" {
     output_path = "${path.module}/../../../../lambda/waf-to-splunk-kinesis-data-transformation/index.zip"
 }
 
-
 resource "aws_lambda_function" "kinesis_data_transformation_lambda" {
   provider         = aws.us
   filename         = data.archive_file.zip_lambda.output_path
@@ -18,6 +17,7 @@ resource "aws_lambda_function" "kinesis_data_transformation_lambda" {
   description      = "An Amazon Kinesis Firehose stream processor that accesses the records in the input and returns them with a processing status."
   source_code_hash = data.archive_file.zip_lambda.output_base64sha256
   runtime          = "nodejs12.x"
+  timeout          = 60
 
   depends_on = [
     aws_iam_role_policy_attachment.lambda_logs, 

--- a/terraform/modules/aws/waf_logging/lambda.tf
+++ b/terraform/modules/aws/waf_logging/lambda.tf
@@ -1,0 +1,38 @@
+data "archive_file" "zip_lambda" {
+    type        = "zip"
+    source_file = "../../../../lambda/waf-to-splunk-kinesis-data-transformation/index.js"
+    output_path = "../../../../lambda/waf-to-splunk-kinesis-data-transformation/index.zip"
+}
+
+
+resource "aws_iam_role" "iam_kinesis_data_transformation_lambda" {
+  name = "iam_kinesis_data_transformation_lambda"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_lambda_function" "kinesis_data_transformation_lambda" {
+  filename      = "../../../../lambda/waf-to-splunk-kinesis-data-transformation/index.zip"
+  function_name = "kinesis_data_transformation_lambda"
+  role          = aws_iam_role.iam_kinesis_data_transformation_lambda.arn
+  handler       = "exports.handler"
+  provider      = aws.us
+
+  source_code_hash = "${filebase64sha256("../../../../lambda/waf-to-splunk-kinesis-data-transformation/index.zip")}"
+
+  runtime = "nodejs12.x"
+}

--- a/terraform/modules/aws/waf_logging/lambda.tf
+++ b/terraform/modules/aws/waf_logging/lambda.tf
@@ -1,9 +1,8 @@
 data "archive_file" "zip_lambda" {
     type        = "zip"
-    source_file = "../../../../lambda/waf-to-splunk-kinesis-data-transformation/index.js"
-    output_path = "../../../../lambda/waf-to-splunk-kinesis-data-transformation/index.zip"
+    source_file = "${path.module}/../../../../lambda/waf-to-splunk-kinesis-data-transformation/index.js"
+    output_path = "${path.module}/../../../../lambda/waf-to-splunk-kinesis-data-transformation/index.zip"
 }
-
 
 resource "aws_iam_role" "iam_kinesis_data_transformation_lambda" {
   name = "iam_kinesis_data_transformation_lambda"
@@ -26,13 +25,12 @@ EOF
 }
 
 resource "aws_lambda_function" "kinesis_data_transformation_lambda" {
-  filename      = "../../../../lambda/waf-to-splunk-kinesis-data-transformation/index.zip"
-  function_name = "kinesis_data_transformation_lambda"
-  role          = aws_iam_role.iam_kinesis_data_transformation_lambda.arn
-  handler       = "exports.handler"
-  provider      = aws.us
-
-  source_code_hash = "${filebase64sha256("../../../../lambda/waf-to-splunk-kinesis-data-transformation/index.zip")}"
-
-  runtime = "nodejs12.x"
+  provider         = aws.us
+  filename         = data.archive_file.zip_lambda.output_path
+  function_name    = "waf-kinesis-splunk-transformation"
+  role             = aws_iam_role.iam_kinesis_data_transformation_lambda.arn
+  handler          = "index.handler"
+  description      = "An Amazon Kinesis Firehose stream processor that accesses the records in the input and returns them with a processing status."
+  source_code_hash = data.archive_file.zip_lambda.output_base64sha256
+  runtime          = "nodejs12.x"
 }

--- a/terraform/modules/aws/waf_logging/s3.tf
+++ b/terraform/modules/aws/waf_logging/s3.tf
@@ -2,31 +2,3 @@ resource "aws_s3_bucket" "waf_log_bucket" {
   bucket = "govuk-pay-waf-logs-${var.environment}"
   acl    = "private"
 }
-
-resource "aws_iam_role_policy" "waf_firehose_s3_policy" {
-    name   = "waf-firehose-s3-policy"
-    role   = aws_iam_role.waf_firehose_iam_role.id
-    policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid": "",
-            "Effect": "Allow",
-            "Action": [
-                "s3:AbortMultipartUpload",
-                "s3:GetBucketLocation",
-                "s3:GetObject",
-                "s3:ListBucket",
-                "s3:ListBucketMultipartUploads",
-                "s3:PutObject"
-            ],
-            "Resource": [
-                "${aws_s3_bucket.waf_log_bucket.arn}",
-                "${aws_s3_bucket.waf_log_bucket.arn}/*"
-            ]
-        }
-    ]
-}
-EOF
-}

--- a/terraform/modules/aws/waf_logging/variables.tf
+++ b/terraform/modules/aws/waf_logging/variables.tf
@@ -2,3 +2,13 @@ variable "environment" {
   type        = string
   description = "Environment name (for example: staging)"
 }
+
+variable "splunk_hec_token" {
+  type        = string
+  description = "HEC Token for Splunk"
+}
+
+variable "splunk_hec_endpoint" {
+  type        = string
+  description = "HEC Endpoint for Splunk"  
+}

--- a/terraform/staging-aws/site.tf
+++ b/terraform/staging-aws/site.tf
@@ -22,7 +22,6 @@ provider "pass" {
   refresh_store = false
 }
 
-
 variable "splunk_hec_token" {
   type        = string
   description = "HEC Token for Splunk"
@@ -41,9 +40,9 @@ module "staging" {
     aws.us = aws.us
   }
 
-  environment       = "staging"
-  domain_name       = "gdspay.uk"
-  paas_domain       = "cloudapps.digital"
+  environment         = "staging"
+  domain_name         = "gdspay.uk"
+  paas_domain         = "cloudapps.digital"
   splunk_hec_endpoint = var.splunk_hec_endpoint
-  splunk_hec_token = var.splunk_hec_token
+  splunk_hec_token    = var.splunk_hec_token
 }

--- a/terraform/staging-aws/site.tf
+++ b/terraform/staging-aws/site.tf
@@ -22,6 +22,17 @@ provider "pass" {
   refresh_store = false
 }
 
+
+variable "splunk_hec_token" {
+  type        = string
+  description = "HEC Token for Splunk"
+}
+
+variable "splunk_hec_endpoint" {
+  type        = string
+  description = "HEC Endpoint for Splunk"  
+}
+
 module "staging" {
   source = "../modules/aws"
 
@@ -33,4 +44,6 @@ module "staging" {
   environment       = "staging"
   domain_name       = "gdspay.uk"
   paas_domain       = "cloudapps.digital"
+  splunk_hec_endpoint = var.splunk_hec_endpoint
+  splunk_hec_token = var.splunk_hec_token
 }


### PR DESCRIPTION
Deploys a Kinesis Firehose Delivery Stream used to process and deliver logs from WAF ACLs to Splunk.

- Uses a lambda function to process logs to required Splunk HEC format
- Drops "Allow" logs, so only Block and Count actions are delivered.
- Failed logs are delivered to an S3 bucket
- Adds log groups and streams for debugging Lambda function and Firehose Delivery
- Requires Splunk HEC Endpoint and Token as input variables