### PR TITLE
PP-6446 Bind Apps to Splunk Log Service

### DIFF
--- a/terraform/modules/paas/adminusers.tf
+++ b/terraform/modules/paas/adminusers.tf
@@ -8,6 +8,10 @@ resource "cloudfoundry_app" "adminusers" {
   stopped = true
   v3      = true
 
+  service_binding {
+    service_instance = cloudfoundry_service_instance.splunk_log_service.id
+  }
+
   lifecycle {
     ignore_changes = [stopped, health_check_type]
   }

--- a/terraform/modules/paas/carbon-relay.tf
+++ b/terraform/modules/paas/carbon-relay.tf
@@ -8,6 +8,10 @@ resource "cloudfoundry_app" "carbon-relay" {
   stopped = true
   v3      = true
 
+  service_binding { 
+    service_instance = cloudfoundry_service_instance.cde_splunk_log_service.id
+  }
+
   lifecycle {
     ignore_changes = [stopped, health_check_type]
   }

--- a/terraform/modules/paas/card-connector.tf
+++ b/terraform/modules/paas/card-connector.tf
@@ -8,6 +8,10 @@ resource "cloudfoundry_app" "card_connector" {
   stopped = true
   v3      = true
 
+  service_binding { 
+    service_instance = cloudfoundry_service_instance.cde_splunk_log_service.id
+  }
+
   lifecycle {
     ignore_changes = [stopped, health_check_type]
   }

--- a/terraform/modules/paas/card-frontend.tf
+++ b/terraform/modules/paas/card-frontend.tf
@@ -8,6 +8,10 @@ resource "cloudfoundry_app" "card_frontend" {
   stopped = true
   v3      = true
 
+  service_binding {
+    service_instance = cloudfoundry_service_instance.cde_splunk_log_service.id
+  }
+
   lifecycle {
     ignore_changes = [stopped, health_check_type]
   }

--- a/terraform/modules/paas/cardid.tf
+++ b/terraform/modules/paas/cardid.tf
@@ -8,6 +8,10 @@ resource "cloudfoundry_app" "cardid" {
   stopped = true
   v3      = true
 
+  service_binding { 
+    service_instance = cloudfoundry_service_instance.cde_splunk_log_service.id
+  }
+
   lifecycle {
     ignore_changes = [stopped, health_check_type]
   }

--- a/terraform/modules/paas/directdebit-connector.tf
+++ b/terraform/modules/paas/directdebit-connector.tf
@@ -7,6 +7,9 @@ resource "cloudfoundry_app" "directdebit_connector" {
   space   = data.cloudfoundry_space.space.id
   stopped = true
   v3      = true
+  service_binding {
+    service_instance = cloudfoundry_service_instance.splunk_log_service.id
+  }
 
   lifecycle {
     ignore_changes = [stopped, health_check_type]

--- a/terraform/modules/paas/directdebit-frontend.tf
+++ b/terraform/modules/paas/directdebit-frontend.tf
@@ -7,6 +7,9 @@ resource "cloudfoundry_app" "directdebit_frontend" {
   space   = data.cloudfoundry_space.space.id
   stopped = true
   v3      = true
+  service_binding { 
+    service_instance = cloudfoundry_service_instance.splunk_log_service.id
+  }
 
   lifecycle {
     ignore_changes = [stopped, health_check_type]

--- a/terraform/modules/paas/ledger.tf
+++ b/terraform/modules/paas/ledger.tf
@@ -8,6 +8,10 @@ resource "cloudfoundry_app" "ledger" {
   stopped = true
   v3      = true
 
+  service_binding {
+    service_instance = cloudfoundry_service_instance.splunk_log_service
+  }
+
   lifecycle {
     ignore_changes = [stopped, health_check_type]
   }

--- a/terraform/modules/paas/metric-exporter.tf
+++ b/terraform/modules/paas/metric-exporter.tf
@@ -8,6 +8,10 @@ resource "cloudfoundry_app" "metric_exporter" {
   stopped = true
   v3      = true
 
+  service_binding { 
+    service_instance = cloudfoundry_service_instance.cde_splunk_log_service.id
+  }
+
   lifecycle {
     ignore_changes = [stopped, health_check_type]
   }

--- a/terraform/modules/paas/notifications.tf
+++ b/terraform/modules/paas/notifications.tf
@@ -5,6 +5,10 @@ resource "cloudfoundry_app" "notifications" {
   docker_image = "alpine:latest"
   v3           = true
 
+  service_binding {
+    service_instance = cloudfoundry_service_instance.splunk_log_service.id
+  }
+
   lifecycle {
     ignore_changes = [stopped, health_check_type, docker_image]
   }

--- a/terraform/modules/paas/products-ui.tf
+++ b/terraform/modules/paas/products-ui.tf
@@ -8,6 +8,10 @@ resource "cloudfoundry_app" "products_ui" {
   stopped = true
   v3      = true
 
+  service_binding { 
+    service_instance = cloudfoundry_service_instance.splunk_log_service.id
+  }
+
   lifecycle {
     ignore_changes = [stopped, health_check_type]
   }

--- a/terraform/modules/paas/products.tf
+++ b/terraform/modules/paas/products.tf
@@ -8,6 +8,10 @@ resource "cloudfoundry_app" "products" {
   stopped = true
   v3      = true
 
+  service_binding { 
+    service_instance = cloudfoundry_service_instance.splunk_log_service.id
+  }
+
   lifecycle {
     ignore_changes = [stopped, health_check_type]
   }

--- a/terraform/modules/paas/publicapi.tf
+++ b/terraform/modules/paas/publicapi.tf
@@ -8,6 +8,10 @@ resource "cloudfoundry_app" "publicapi" {
   stopped = true
   v3      = true
 
+  service_binding { 
+    service_instance = cloudfoundry_service_instance.splunk_log_service.id
+  }
+
   lifecycle {
     ignore_changes = [stopped, health_check_type]
   }

--- a/terraform/modules/paas/publicauth.tf
+++ b/terraform/modules/paas/publicauth.tf
@@ -8,6 +8,10 @@ resource "cloudfoundry_app" "publicauth" {
   stopped = true
   v3      = true
 
+  service_binding {
+    service_instance = cloudfoundry_service_instance.splunk_log_service.id
+  }
+
   lifecycle {
     ignore_changes = [stopped, health_check_type]
   }

--- a/terraform/modules/paas/selfservice.tf
+++ b/terraform/modules/paas/selfservice.tf
@@ -8,6 +8,10 @@ resource "cloudfoundry_app" "selfservice" {
   stopped = true
   v3      = true
 
+  service_binding {
+    service_instance = cloudfoundry_service_instance.splunk_log_service
+  }
+
   lifecycle {
     ignore_changes = [stopped, health_check_type]
   }

--- a/terraform/modules/paas/splunk-log-drain.tf
+++ b/terraform/modules/paas/splunk-log-drain.tf
@@ -6,6 +6,7 @@ resource "cloudfoundry_service_instance" "splunk_log_service" {
   name            = "splunk-log-service"
   service_plan    = data.cloudfoundry_service.splunk.service_plans["unlimited"]
   space           = data.cloudfoundry_space.space.id
+
   lifecycle {
     prevent_destroy = true
   }
@@ -15,6 +16,7 @@ resource "cloudfoundry_service_instance" "cde_splunk_log_service" {
   name            = "splunk-log-service"
   service_plan    = data.cloudfoundry_service.splunk.service_plans["unlimited"]
   space           = data.cloudfoundry_space.cde_space.id
+
   lifecycle {
     prevent_destroy = true
   }

--- a/terraform/modules/paas/splunk-log-drain.tf
+++ b/terraform/modules/paas/splunk-log-drain.tf
@@ -6,12 +6,16 @@ resource "cloudfoundry_service_instance" "splunk_log_service" {
   name            = "splunk-log-service"
   service_plan    = data.cloudfoundry_service.splunk.service_plans["unlimited"]
   space           = data.cloudfoundry_space.space.id
-  prevent_destroy = true
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "cloudfoundry_service_instance" "cde_splunk_log_service" {
   name            = "splunk-log-service"
   service_plan    = data.cloudfoundry_service.splunk.service_plans["unlimited"]
   space           = data.cloudfoundry_space.cde_space.id
-  prevent_destroy = true
+  lifecycle {
+    prevent_destroy = true
+  }
 }

--- a/terraform/modules/paas/toolbox.tf
+++ b/terraform/modules/paas/toolbox.tf
@@ -8,6 +8,10 @@ resource "cloudfoundry_app" "toolbox" {
   stopped = true
   v3      = true
 
+  service_binding { 
+    service_instance = cloudfoundry_service_instance.splunk_log_service.id
+  }
+
   lifecycle {
     ignore_changes = [stopped, health_check_type]
   }


### PR DESCRIPTION
Binds all applications & ancillary apps (carbon relay / metric exporter) to Splunk log service.

This is a managed service run by Cyber. Logs are currently pushed to `pay_testing` index. This can be changed by Cyber.