### PR TITLE
BAU: Source Splunk HEC token from pay-low-pass secret store

### DIFF
--- a/terraform/modules/aws/logs.tf
+++ b/terraform/modules/aws/logs.tf
@@ -3,9 +3,14 @@ resource "aws_s3_bucket" "cloudfront_logs" {
   acl    = "private"
 }
 
+data "pass_password" "splunk_hec_token" {
+  path = "splunk/paas/hec_token"
+  provider = pass.low-pass
+}
+
 module "waf_logging" {
-  source = "./waf_logging"
-  environment = var.environment
-  splunk_hec_endpoint = var.splunk_hec_endpoint
-  splunk_hec_token = var.splunk_hec_token
+  source              = "./waf_logging"
+  environment         = var.environment
+  splunk_hec_endpoint = "https://http-inputs-gds.splunkcloud.com"
+  splunk_hec_token    = data.pass_password.splunk_hec_token.password
 }

--- a/terraform/modules/aws/main.tf
+++ b/terraform/modules/aws/main.tf
@@ -1,3 +1,7 @@
 provider "aws" {
   alias = "us"
 }
+
+provider "pass" {
+  alias = "low-pass"
+}

--- a/terraform/modules/aws/variables.tf
+++ b/terraform/modules/aws/variables.tf
@@ -12,13 +12,3 @@ variable "paas_domain" {
   type        = string
   description = "PaaS domain for Cloudfront origin"
 }
-
-variable "splunk_hec_token" {
-  type        = string
-  description = "HEC Token for Splunk"
-}
-
-variable "splunk_hec_endpoint" {
-  type        = string
-  description = "HEC Endpoint for Splunk"  
-}

--- a/terraform/staging-aws/site.tf
+++ b/terraform/staging-aws/site.tf
@@ -18,31 +18,29 @@ provider "aws" {
 }
 
 provider "pass" {
+  version       = "~> 1.2"
   store_dir     = "../../secrets"
   refresh_store = false
 }
 
-variable "splunk_hec_token" {
-  type        = string
-  description = "HEC Token for Splunk"
-}
-
-variable "splunk_hec_endpoint" {
-  type        = string
-  description = "HEC Endpoint for Splunk"  
+provider "pass" {
+  version       = "~> 1.2"
+  store_dir     = "../../../pay-low-pass"
+  refresh_store = false
+  alias         = "low-pass"
 }
 
 module "staging" {
   source = "../modules/aws"
 
   providers = {
-    aws    = aws
-    aws.us = aws.us
+    aws           = aws
+    aws.us        = aws.us
+    pass          = pass
+    pass.low-pass = pass.low-pass
   }
 
   environment         = "staging"
   domain_name         = "gdspay.uk"
   paas_domain         = "cloudapps.digital"
-  splunk_hec_endpoint = var.splunk_hec_endpoint
-  splunk_hec_token    = var.splunk_hec_token
 }


### PR DESCRIPTION
Refactors AWS Terraform to source Splunk HEC token used by WAF log Kinesis delivery pipeline from pay-low-pass rather than an input variable.