### PR TITLE
BAU: Apply explicit public access block to s3 buckets

### DIFF
--- a/terraform/modules/aws/logs.tf
+++ b/terraform/modules/aws/logs.tf
@@ -3,6 +3,15 @@ resource "aws_s3_bucket" "cloudfront_logs" {
   acl    = "private"
 }
 
+resource "aws_s3_bucket_public_access_block" "cloudfront_logs" {
+  bucket = aws_s3_bucket.cloudfront_logs.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
 data "pass_password" "splunk_hec_token" {
   path = "splunk/paas/hec_token"
   provider = pass.low-pass

--- a/terraform/modules/aws/waf_logging/s3.tf
+++ b/terraform/modules/aws/waf_logging/s3.tf
@@ -2,3 +2,12 @@ resource "aws_s3_bucket" "waf_log_bucket" {
   bucket = "govuk-pay-waf-logs-${var.environment}"
   acl    = "private"
 }
+
+resource "aws_s3_bucket_public_access_block" "waf_log_bucket" {
+  bucket = aws_s3_bucket.waf_log_bucket.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}

--- a/terraform/staging-account/site.tf
+++ b/terraform/staging-account/site.tf
@@ -31,3 +31,12 @@ resource "aws_s3_bucket" "tfstate" {
     prevent_destroy = true
   }
 }
+
+resource "aws_s3_bucket_public_access_block" "tfstate" {
+  bucket = aws_s3_bucket.tfstate.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}


### PR DESCRIPTION
Buckets already had private ACLs applied. An explicit public access
block ensures any ACL or IAM policies created later on can not accidentally 
make objects public.

This is a relatively new feature to prevent misconfiguration of
bucket and object policies.

See: https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html

Terraform has been applied.