### PR TITLE
PP-6234: Enable SSE on all SQS queues

### DIFF
--- a/terraform/modules/aws/sqs.tf
+++ b/terraform/modules/aws/sqs.tf
@@ -7,10 +7,12 @@ resource "aws_sqs_queue" "capture" {
       deadLetterTargetArn = aws_sqs_queue.capture_dead_letter.arn
       maxReceiveCount     = 2
   })
+  kms_master_key_id          = data.aws_kms_key.sqs_sse_key.arn
 }
 
 resource "aws_sqs_queue" "capture_dead_letter" {
-  name = "${var.environment}-capture-dead-letter"
+  name              = "${var.environment}-capture-dead-letter"
+  kms_master_key_id = data.aws_kms_key.sqs_sse_key.arn
 }
 
 resource "aws_sqs_queue" "payment_event" {
@@ -22,10 +24,12 @@ resource "aws_sqs_queue" "payment_event" {
       deadLetterTargetArn = aws_sqs_queue.payment_event_dead_letter.arn
       maxReceiveCount     = 2
   })
+  kms_master_key_id          = data.aws_kms_key.sqs_sse_key.arn
 }
 
 resource "aws_sqs_queue" "payment_event_dead_letter" {
-  name = "${var.environment}-payment-event-dead-letter"
+  name              = "${var.environment}-payment-event-dead-letter"
+  kms_master_key_id = data.aws_kms_key.sqs_sse_key.arn
 }
 
 resource "aws_sqs_queue" "payout_reconcile" {
@@ -37,8 +41,15 @@ resource "aws_sqs_queue" "payout_reconcile" {
       deadLetterTargetArn = aws_sqs_queue.payout_reconcile_dead_letter.arn
       maxReceiveCount     = 2
   })
+  kms_master_key_id          = data.aws_kms_key.sqs_sse_key.arn
 }
 
 resource "aws_sqs_queue" "payout_reconcile_dead_letter" {
-  name = "${var.environment}-payout-reconcile-dead-letter"
+  name              = "${var.environment}-payout-reconcile-dead-letter"
+  kms_master_key_id = data.aws_kms_key.sqs_sse_key.arn
+}
+
+data "aws_kms_key" "sqs_sse_key" {
+  // Default SQS encryption key
+  key_id = "alias/aws/sqs"
 }


### PR DESCRIPTION
Uses the default master KMS key managed by AWS. Messages are
encrypted and decrypted by applications using temporary keys
requested from KMS.

This occurs transparently when using AWS SDK SQS client.

More information: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html