### PR TITLE
PP-6234: Add PaaS Ireland public IPs to TF variables

### DIFF
--- a/terraform/modules/aws/variables.tf
+++ b/terraform/modules/aws/variables.tf
@@ -12,3 +12,8 @@ variable "paas_domain" {
   type        = string
   description = "PaaS domain for Cloudfront origin"
 }
+
+variable "paas_public_ips" {
+  type = list
+  default = [ "52.208.24.161", "52.208.1.143", "52.51.250.21" ]
+}


### PR DESCRIPTION
Public static egress IPs for PaaS Ireland.

These may be used to create AWS resource IP restrictions etc.