### PR TITLE
PP-6234: Remove stub SQS service and add real queue config

### DIFF
--- a/terraform/modules/paas/sqs-config-service.tf
+++ b/terraform/modules/paas/sqs-config-service.tf
@@ -1,9 +1,12 @@
-sqs_config = {
-  region                     = var.aws_region
-  capture_queue_url          = "https://sqs.${var.aws_region}.amazonaws.com/${var.aws_account_id}/${var.environment}-capture"
-  event_queue_url            = "https://sqs.${var.aws_region}.amazonaws.com/${var.aws_account_id}/${var.environment}-payment-event"
-  payout_reconcile_queue_url = "https://sqs.${var.aws_region}.amazonaws.com/${var.aws_account_id}/${var.environment}-payout-reconcile"
+locals {
+  sqs_config = {
+    region                     = var.aws_region
+    capture_queue_url          = "https://sqs.${var.aws_region}.amazonaws.com/${var.aws_account_id}/${var.environment}-capture"
+    event_queue_url            = "https://sqs.${var.aws_region}.amazonaws.com/${var.aws_account_id}/${var.environment}-payment-event"
+    payout_reconcile_queue_url = "https://sqs.${var.aws_region}.amazonaws.com/${var.aws_account_id}/${var.environment}-payout-reconcile"
+  }
 }
+
 
 resource "cloudfoundry_user_provided_service" "sqs-cde" {
   name  = "sqs"

--- a/terraform/modules/paas/sqs-config-service.tf
+++ b/terraform/modules/paas/sqs-config-service.tf
@@ -1,0 +1,20 @@
+sqs_config = {
+  region                     = var.aws_region
+  capture_queue_url          = "https://sqs.${var.aws_region}.amazonaws.com/${var.aws_account_id}/${var.environment}-capture"
+  event_queue_url            = "https://sqs.${var.aws_region}.amazonaws.com/${var.aws_account_id}/${var.environment}-payment-event"
+  payout_reconcile_queue_url = "https://sqs.${var.aws_region}.amazonaws.com/${var.aws_account_id}/${var.environment}-payout-reconcile"
+}
+
+resource "cloudfoundry_user_provided_service" "sqs-cde" {
+  name  = "sqs"
+  space = data.cloudfoundry_space.cde_space.id
+
+  credentials = local.sqs_config
+}
+
+resource "cloudfoundry_user_provided_service" "sqs" {
+  name  = "sqs"
+  space = data.cloudfoundry_space.space.id
+
+  credentials = local.sqs_config
+}

--- a/terraform/modules/paas/variables.tf
+++ b/terraform/modules/paas/variables.tf
@@ -8,6 +8,11 @@ variable "space" {
   description = "PaaS space"
 }
 
+variable "environment" {
+  type        = string
+  description = "The application environment e.g. dev, staging or production"
+}
+
 variable "external_domain" {
   type        = string
   description = "Domain for external app routes"
@@ -28,4 +33,14 @@ variable "external_hostname_suffix" {
 variable "credentials" {
   type        = map(map(map(string)))
   description = "credential for the apps"
+}
+
+variable "aws_region" {
+  type        = string
+  description = "Name of AWS region to use in configuration values e.g. eu-west-2"
+}
+
+variable "aws_account_id" {
+  type        = string
+  description = "AWS account id to use in configuration passed to user provided services etc."
 }

--- a/terraform/staging-paas/site.tf
+++ b/terraform/staging-paas/site.tf
@@ -46,13 +46,3 @@ module "paas_postgres" {
   org   = "govuk-pay"
   space = "staging"
 }
-
-data "terraform_remote_state" "aws" {
-  backend "s3"
-
-  config = {
-    bucket = "govuk-pay-terraform-state"
-    key    = "staging"
-    region = "eu-west-2"
-  }
-}


### PR DESCRIPTION
- Adds an SQS config user-provided service to provide queue URLs to apps.
- Queue URLs are built from AWS region, account id, and environment variables.
- Apps are still bound to SQS config service via app manifest in their respective repositories.
- Connector will need updating to add payout reconcile config via `env-map.yml`