### PR TITLE
PP-6234: Fix database migration tasks running in Java buildpack

### DIFF
--- a/ci/scripts/migrate_database.sh
+++ b/ci/scripts/migrate_database.sh
@@ -5,12 +5,7 @@ set -o errexit -o nounset
 : "${APP_PACKAGE:?APP_PACKAGE is required (e.g. uk.gov.pay.connector.ConnectorApplication)}"
 
 function createCommandFor() {
-  echo "/home/vcap/app/.java-buildpack/open_jdk_jre/bin/java \
--Djava.security.properties=/home/vcap/app/.java-buildpack/java_security/java.security -Xms512m -Xmx1G \
--cp /home/vcap/app/.:/home/vcap/app/.java-buildpack/client_certificate_mapper/client_certificate_mapper-1.11.0_RELEASE.jar:\
-/home/vcap/app/.java-buildpack/postgresql_jdbc/postgresql_jdbc-42.2.9.jar:\
-/home/vcap/app/.java-buildpack/container_security_provider/container_security_provider-1.16.0_RELEASE.jar \
-${APP_PACKAGE} ${1} /home/vcap/app/config/config.yaml"
+  echo "source <(jq -r .\"start_command\" /home/vcap/staging_info.yml | sed 's/server/${1}/g')"
 }
 
 TASK_COMMAND=$(createCommandFor "db migrate")


### PR DESCRIPTION
The correct java command options for the current buildpack runtime can be found in `/home/vcap/staging_info.yml`. 

`server` is replaced with the migration command(s), for the given app.

jq is also available in the runtime to allow this to be parsed for use with CF tasks. This should keep tasks stable as buildpacks are updated.

Co-authored-by: Rory Malcolm <rory.malcolm@digital.cabinet-office.gov.uk>