### PR TITLE
Toolbox doesn't have pact files so don't error if they're not there

### DIFF
--- a/ci/tasks/node-build-pr.yml
+++ b/ci/tasks/node-build-pr.yml
@@ -44,4 +44,4 @@ run:
 
       cp -R src/* build
       cp -R src/.git build
-      cp -R src/pacts/* pacts/
+      cp -R src/pacts/* pacts/ || true


### PR DESCRIPTION
Alex raised a pr on Toolbox and the build failed when trying to copy the non-existent pact files. This allows that step to pass if they do not exist.

Tested on pr pipeline and it passes.
https://cd.gds-reliability.engineering/teams/pay-deploy/pipelines/pr-ci/jobs/toolbox-test/builds/53