### PR TITLE
Fix yml formatting

### DIFF
--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -1446,9 +1446,9 @@ jobs:
       params:
         consumer: frontend
         provider: connector
-    on_failure:
-      <<: *put-pact-provider-failed-status
-      put: card-frontend-pull-request
+      on_failure:
+        <<: *put-pact-provider-failed-status
+        put: card-frontend-pull-request
     - <<: *put-pact-provider-success-status
       put: card-frontend-pull-request
 


### PR DESCRIPTION
Somehow the pr pipeline on master couldn't actually be set because of the  incorrect indentation fixed herein.

