### PR TITLE
PP-6676 fix calculation of next release number

### DIFF
--- a/ci/tasks/calculate-release-number.yml
+++ b/ci/tasks/calculate-release-number.yml
@@ -23,10 +23,10 @@ run:
 
       # calculate next release number
       set +e
-      latest_release_number=$(git tag --list 'paas_release-*' | sort -nr | head -1 | cut -d "-" -f 2 || true)
-      is_numeric=$(echo ${latest_release_number} | egrep -E '^[0-9]+$')
+      latest_release_number=$(git tag --list 'paas_release-*' | cut -d "-" -f 2  | sort -nr | head -1 || true)
+      is_numeric=$(echo "$latest_release_number" | grep -E '^[0-9]+$')
 
-      if ! [ is_numeric ]; then
+      if ! [ "$is_numeric" ]; then
         latest_release_number=0
       fi
 


### PR DESCRIPTION
`cut` the release number before sorting since sort even with the `-n` flag
doesn't appreciate that `paas_release-10` is greater than
`paas_release-9` and we were forever stuck creating release 10.

Also ran shellcheck and fixed one error to correctly reference
`is_numeric` (there was no `$`) and double quoted variables to keep it
happy and avoid globbing/word splitting.

Example of previous calculation:
```
GDS5062:pay-frontend danworth$ git tag --list 'paas_release-*' | sort -nr
paas_release-9
paas_release-8
paas_release-7
paas_release-6
paas_release-5
paas_release-4
paas_release-3
paas_release-2
paas_release-10
paas_release-1
```