### PR TITLE
PP-6606: Run Cypress tests on Node apps if config is present

### DIFF
--- a/ci/tasks/node-build-pr.yml
+++ b/ci/tasks/node-build-pr.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: node
-    tag: 12-alpine
+    tag: 12-stretch
 inputs:
   - name: src
 outputs:
@@ -14,8 +14,9 @@ outputs:
   - name: pacts
 caches:
   - path: npm_cache
+  - path: cypress_cache
 run:
-  path: sh
+  path: bash
   dir: src
   args:
     - -ec
@@ -24,21 +25,21 @@ run:
       echo "node: $(node --version)"
       echo "npm: $(npm --version)"
 
-      apk update
-      apk upgrade
-      apk add --update --virtual build-dependencies build-base
-      apk add --update bash ca-certificates wget python
+      apt-get update
+      apt-get -y install ca-certificates wget python libgtk2.0-0 libgtk-3-0 libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
 
-      # For Pact. See: https://docs.pact.io/docker#alpine-linux
-      wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub
-      wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.29-r0/glibc-2.29-r0.apk
-      apk add glibc-2.29-r0.apk
-
+      export CYPRESS_CACHE_FOLDER=$(pwd)/../cypress_cache
       npm config set cache ../npm_cache
       npm rebuild node-sass
       npm ci
       npm run compile
       npm test -- --forbid-only --forbid-pending
+
+      if [ -f "cypress.json" ]; then
+        npm run cypress:server > /dev/null 2>&1 &
+        sleep 3
+        npm run cypress:test
+      fi
 
       cd ..
 


### PR DESCRIPTION
**What is it?**
This change enables Cypress tests for frontend projects by detecting the `cypress.json` file in the project root. Tests now run and pass:

https://cd.gds-reliability.engineering/teams/pay-deploy/pipelines/pr-ci/jobs/selfservice-test/builds/170

To do this I have needed to change the node pr-build container to node Debian Stretch from Alpine. This is because Cypress requires libc dependencies not available on Alpine.

Cypress is installed by npm as a development dependency and this is cached by the Concourse task worker.

One drawback to this is that unit/cypress/e2e tests are each run serially.

**Future Solution**

A possible solution to parallelize this work is to create a new “cypress” test task for frontend build jobs. This can be executed in parallel with other tasks. Instead of installing cypress via npm, the Concourse task can use the `cypress/included` docker image which also includes Node and is designed with this use-case in mind. This can be cached by the Concourse worker. The source code can be mounted into the container as a volume and the server started as normal.

https://docs.cypress.io/examples/examples/docker.html#Images