### PR TITLE
BAU: Prevent builds triggered by external forks

### DIFF
--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -566,6 +566,7 @@ resources:
     icon: github-circle
     check_every: 1h
     source: &pull-request-source
+      disable_forks: true
       repository: alphagov/pay-connector
       access_token: ((github-access-token))
 


### PR DESCRIPTION
Prevents Concourse running PR builds on external, untrusted forks.