### PR TITLE
BAU: Update github material design icon used in pipelines

### DIFF
--- a/ci/pipelines/concourse-runner.yml
+++ b/ci/pipelines/concourse-runner.yml
@@ -2,7 +2,7 @@
 resources:
   - name: concourse-runner-src
     type: git
-    icon: github-circle
+    icon: github
     source:
       uri: https://github.com/alphagov/pay-omnibus
       branch: master

--- a/ci/pipelines/deploy.yml
+++ b/ci/pipelines/deploy.yml
@@ -131,7 +131,7 @@ resource_types:
 resources:
   - name: omnibus
     type: git
-    icon: github-circle
+    icon: github
     source:
       uri: https://github.com/alphagov/pay-omnibus
       branch: master
@@ -163,7 +163,7 @@ resources:
 
   - name: carbon-relay-source
     type: git
-    icon: github-circle
+    icon: github
     source:
       uri: https://github.com/alphagov/pay-omnibus
       branch: master
@@ -174,7 +174,7 @@ resources:
   - &git-repo
     name: toolbox-source
     type: git
-    icon: github-circle
+    icon: github
     source: &git-repo-source
       uri: https://github.com/alphagov/pay-toolbox
       branch: master
@@ -307,7 +307,7 @@ resources:
 
   - name: cardid-data-source
     type: git
-    icon: github-circle
+    icon: github
     source:
       username: alphagov-pay-ci
       password: ((github-access-token))

--- a/ci/pipelines/dev-env.yml
+++ b/ci/pipelines/dev-env.yml
@@ -8,14 +8,14 @@ resource_types:
 resources:
   - name: omnibus
     type: git
-    icon: github-circle
+    icon: github
     source:
       uri: https://github.com/alphagov/pay-omnibus
       branch: master
 
   - name: omnibus-paas
     type: git
-    icon: github-circle
+    icon: github
     source:
       uri: https://github.com/alphagov/pay-omnibus
       branch: master

--- a/ci/pipelines/dev-pipelines.yml
+++ b/ci/pipelines/dev-pipelines.yml
@@ -8,7 +8,7 @@ resource_types:
 resources:
   - name: omnibus
     type: git
-    icon: github-circle
+    icon: github
     source:
       uri: https://github.com/alphagov/pay-omnibus
       branch: master

--- a/ci/pipelines/docs.yml
+++ b/ci/pipelines/docs.yml
@@ -8,7 +8,7 @@ resource_types:
 resources:
   - name: omnibus-docs
     type: git
-    icon: github-circle
+    icon: github
     source:
       uri: https://github.com/alphagov/pay-omnibus
       branch: master

--- a/ci/pipelines/pay-tech-docs.yml
+++ b/ci/pipelines/pay-tech-docs.yml
@@ -8,7 +8,7 @@ resource_types:
 resources:
   - name: pay-tech-docs
     type: git
-    icon: github-circle
+    icon: github
     source:
       uri: https://github.com/alphagov/pay-tech-docs
       branch: master

--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -392,37 +392,37 @@ resource_types:
 resources:
   - name: card-connector-master
     type: git
-    icon: github-circle
+    icon: github
     source:
       uri: https://github.com/alphagov/pay-connector
       branch: master
   - name: ledger-master
     type: git
-    icon: github-circle
+    icon: github
     source:
       uri: https://github.com/alphagov/pay-ledger
       branch: master
   - name: adminusers-master
     type: git
-    icon: github-circle
+    icon: github
     source:
       uri: https://github.com/alphagov/pay-adminusers
       branch: master
   - name: products-master
     type: git
-    icon: github-circle
+    icon: github
     source:
       uri: https://github.com/alphagov/pay-products
       branch: master
   - name: directdebit-connector-master
     type: git
-    icon: github-circle
+    icon: github
     source:
       uri: https://github.com/alphagov/pay-direct-debit-connector
       branch: master
   - name: pr-ci-pipeline
     type: git
-    icon: github-circle
+    icon: github
     source:
       uri: https://github.com/alphagov/pay-omnibus
       branch: master
@@ -431,7 +431,7 @@ resources:
 
   - name: omnibus
     type: git
-    icon: github-circle
+    icon: github
     source:
       uri: https://github.com/alphagov/pay-omnibus
       branch: master
@@ -557,7 +557,7 @@ resources:
   - &pull-request
     name: card-connector-pull-request
     type: pull-request
-    icon: github-circle
+    icon: github
     check_every: 1h
     source: &pull-request-source
       disable_forks: true


### PR DESCRIPTION
`github-circle` appears to have been removed from https://materialdesignicons.com.

This updates all references accordingly.