### PR TITLE
PP 6687 tag consumer master merges

### DIFF
--- a/ci/pipelines/deploy.yml
+++ b/ci/pipelines/deploy.yml
@@ -406,6 +406,10 @@ jobs:
       - get: src
         resource: card-frontend-source
         trigger: true
+      - task: tag-pacts-with-master
+        file: omnibus/ci/tasks/tag-pacts-with-master.yml
+        params:
+          consumer_name: frontend
       - task: calculate-release-number
         file: omnibus/ci/tasks/calculate-release-number.yml
       - task: build-app
@@ -444,6 +448,10 @@ jobs:
       - get: src
         resource: products-ui-source
         trigger: true
+      - task: tag-pacts-with-master
+        file: omnibus/ci/tasks/tag-pacts-with-master.yml
+        params:
+          consumer_name: products-ui
       - task: calculate-release-number
         file: omnibus/ci/tasks/calculate-release-number.yml
       - task: build-app
@@ -461,6 +469,10 @@ jobs:
       - get: src
         resource: selfservice-source
         trigger: true
+      - task: tag-pacts-with-master
+        file: omnibus/ci/tasks/tag-pacts-with-master.yml
+        params:
+          consumer_name: selfservice
       - task: calculate-release-number
         file: omnibus/ci/tasks/calculate-release-number.yml
       - task: build-app
@@ -469,7 +481,7 @@ jobs:
           APP_NAME: pay-selfservice
       - put: release
         resource: git-selfservice-pre-release
-        params: 
+        params:
           <<: *release-params
 
   - name: build-directdebit-frontend
@@ -529,6 +541,10 @@ jobs:
       - get: src
         resource: publicapi-source
         trigger: true
+      - task: tag-pacts-with-master
+        file: omnibus/ci/tasks/tag-pacts-with-master.yml
+        params:
+          consumer_name: publicapi
       - task: calculate-release-number
         file: omnibus/ci/tasks/calculate-release-number.yml
       - task: build-app
@@ -601,6 +617,10 @@ jobs:
       - get: src
         resource: ledger-source
         trigger: true
+      - task: tag-pacts-with-master
+        file: omnibus/ci/tasks/tag-pacts-with-master.yml
+        params:
+          consumer_name: ledger
       - task: calculate-release-number
         file: omnibus/ci/tasks/calculate-release-number.yml
       - task: build-app

--- a/ci/tasks/tag-pacts-with-master.yml
+++ b/ci/tasks/tag-pacts-with-master.yml
@@ -1,0 +1,24 @@
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: rorymalcolm/pay-docker-scratches
+inputs:
+  - name: src
+params:
+  consumer_name: selfservice
+run:
+  path: sh
+  dir: src
+  args:
+    - -c
+    - |
+      pr_commit="$(git rev-list --no-merges -n 1 HEAD)"
+      if [ -z "$pr_commit" ]; then
+        echo "cannot extract pr commit from head of master branch"
+        exit 1
+      fi
+
+      echo "tagging commits with with version ${pr_commit}"
+      curl -v --fail -X PUT -H "Content-Type: application/json" \
+      https://pay-concourse-pact-broker.cloudapps.digital/pacticipants/"${consumer_name}"/versions/"${pr_commit}"/tags/master


### PR DESCRIPTION
```
    PP-6686 Tag consumer master pacts with master

    Upon merge commit of a consumer find the previous commit that was not a
    merge. This should be the head commit of the PR that was tested and
    which was just merged. The pact broker will have contracts for this version
    of the consumer. Use curl to tag them with "master".

    This avoids generating the pacts a second time for node apps which
    would require an npm install which is costly.

    This was the simplest solution at the time and we may want to revist it.
```