### PR TITLE
PP-6704 Run provider pact validation on master merge

### DIFF
--- a/ci/pipelines/deploy.yml
+++ b/ci/pipelines/deploy.yml
@@ -1,5 +1,5 @@
 ---
-definitions: 
+definitions:
   - &notify-hg
     task: change-this-value
     file: omnibus/ci/tasks/send-hg-metric.yml
@@ -8,7 +8,13 @@ definitions:
       HOSTED_GRAPHITE_API_KEY: change-this-value
       METRIC_NAME: change-this-value
       METRIC_VALUE: 0
-
+  - &verify-provider-with-consumer
+    task: verify-provider-with-consumer-master-pacts
+    privileged: true
+    file: omnibus/ci/tasks/pact-provider-master-verification.yml
+    params:
+      consumer: change-this-value
+      provider: change-this-value
 groups:
   - name: Adminusers
     jobs:
@@ -524,6 +530,27 @@ jobs:
       - get: src
         resource: card-connector-source
         trigger: true
+      - in_parallel:
+        - <<: *verify-provider-with-consumer
+          task: verify-with-publicapi
+          params:
+            consumer: publicapi
+            provider: connector
+        - <<: *verify-provider-with-consumer
+          task: verify-with-frontend
+          params:
+            consumer: frontend
+            provider: connector
+        - <<: *verify-provider-with-consumer
+          task: verify-with-selfservice
+          params:
+            consumer: selfservice
+            provider: connector
+        - <<: *verify-provider-with-consumer
+          task: verify-with-ledger
+          params:
+            consumer: ledger
+            provider: connector
       - task: calculate-release-number
         file: omnibus/ci/tasks/calculate-release-number.yml
       - task: build-app
@@ -579,6 +606,17 @@ jobs:
       - get: src
         resource: adminusers-source
         trigger: true
+      - in_parallel:
+        - <<: *verify-provider-with-consumer
+          task: verify-with-products-ui
+          params:
+            consumer: products-ui
+            provider: adminusers
+        - <<: *verify-provider-with-consumer
+          task: verify-with-selfservice
+          params:
+            consumer: selfservice
+            provider: adminusers
       - task: calculate-release-number
         file: omnibus/ci/tasks/calculate-release-number.yml
       - task: build-app
@@ -600,6 +638,17 @@ jobs:
       - get: src
         resource: products-source
         trigger: true
+      - in_parallel:
+        - <<: *verify-provider-with-consumer
+          task: verify-with-products-ui
+          params:
+            consumer: products-ui
+            provider: products
+        - <<: *verify-provider-with-consumer
+          task: verify-with-selfservice
+          params:
+            consumer: selfservice
+            provider: products
       - task: calculate-release-number
         file: omnibus/ci/tasks/calculate-release-number.yml
       - task: build-app
@@ -621,6 +670,17 @@ jobs:
         file: omnibus/ci/tasks/tag-pacts-with-master.yml
         params:
           consumer_name: ledger
+      - in_parallel:
+        - <<: *verify-provider-with-consumer
+          task: verify-with-publicapi
+          params:
+            consumer: publicapi
+            provider: ledger
+        - <<: *verify-provider-with-consumer
+          task: verify-with-selfservice
+          params:
+            consumer: selfservice
+            provider: ledger
       - task: calculate-release-number
         file: omnibus/ci/tasks/calculate-release-number.yml
       - task: build-app

--- a/ci/tasks/pact-provider-master-verification.yml
+++ b/ci/tasks/pact-provider-master-verification.yml
@@ -1,0 +1,48 @@
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: rorymalcolm/pay-docker-scratches
+params:
+  consumer:
+  provider:
+inputs:
+  - name: src
+run:
+  path: bash
+  dir: src
+  args:
+    - -ec
+    - |
+
+      function cleanup {
+        echo "CLEANUP TRIGGERED"
+        clean_docker
+        stop_docker
+        echo "CLEANUP COMPLETE"
+      }
+
+      trap cleanup EXIT
+      source /docker-helpers.sh
+
+      pr_sha="$(git rev-list --no-merges -n 1 HEAD)"
+      if pact-broker can-i-deploy --pacticipant="$provider" \
+                               --version="$pr_sha" \
+                               --pacticipant="$consumer" \
+                               --latest="master" \
+                               --broker_base_url='https://pay-concourse-pact-broker.cloudapps.digital'; then
+        echo "Pacts are valid"
+        exit 0;
+      fi
+
+      start_docker
+
+      mvn test \
+        -DrunContractTests \
+        -DCONSUMER="$consumer" \
+        -DPACT_CONSUMER_TAG="master" \
+        -Dpact.provider.version="$pr_sha" \
+        -Dpact.verifier.publishResults=true \
+        -DPACT_BROKER_HOST=pay-concourse-pact-broker.cloudapps.digital \
+        -DPACT_BROKER_USERNAME=b \
+        -DPACT_BROKER_PASSWORD=a

--- a/ci/tasks/pact-provider-test-preflight-check.yml
+++ b/ci/tasks/pact-provider-test-preflight-check.yml
@@ -16,9 +16,9 @@ run:
     - |
 
       function pacts_already_verified(){
-          TAG="$(cat src/.git/resource/head_sha)"
+          git_sha="$(cat src/.git/resource/head_sha)"
           can_deploy="$(pact-broker can-i-deploy \
-            --pacticipant="$consumer" --version="$TAG" \
+            --pacticipant="$consumer" --version="$git_sha" \
             --broker_base_url='https://pay-concourse-pact-broker.cloudapps.digital')"
           return $?
       }


### PR DESCRIPTION
When a provider is merged into master run pact validation using the
commit one before the merge commit which will be the commit from the
head of the PR. The pact broker will know about this commit since it
will have been tested during the PR build leading up to this merge. If the
pacts with its consumers are still valid then exit. If not then rerun
the validation for the consumer. If the rerun fails then manual
intervention will be necessary as it would be today with Jenkins CI.

**HOW**
This has been set to our deploy pipeline and it looks good so far, for example 
https://cd.gds-reliability.engineering/teams/pay-deploy/pipelines/deploy/jobs/build-card-connector/builds/25

Also we ran through the plan with Oz and he was onboard. I think we can bring together some of the pact verification scripts but at present there are subtle differences that mean they can't be reused as is.
