### PR TITLE
BAU Fix cf run-task command to add --command

### DIFF
--- a/ci/scripts/migrate_database.sh
+++ b/ci/scripts/migrate_database.sh
@@ -15,7 +15,7 @@ if [[ "$APP_NAME" == 'adminusers' ]]; then
   TASK_COMMAND="${INITIAL_MIGRATION} && ${TASK_COMMAND}";
 fi
 
-cf run-task "${APP_NAME}" "${TASK_COMMAND}" --name "${APP_NAME}-db-migration"
+cf run-task "${APP_NAME}" --command "${TASK_COMMAND}" --name "${APP_NAME}-db-migration"
 
 echo "You can view the raw logs using: cf logs ${APP_NAME} --recent"
 echo "Fetching task logs:"


### PR DESCRIPTION
Need to add `--command` to run-task for this to work, perhaps something has recently
changed. I've tried this on a hijacked card-connector container and it worked.

```
USAGE:
   cf run-task APP_NAME [--command COMMAND] [-k DISK] [-m MEMORY]
   [--name TASK_NAME] [--process PROCESS_TYPE]
```
## WHAT ###
Original error:
```
Incorrect Usage: unexpected argument "source <(jq -r ."start_command" /home/vcap/staging_info.yml | sed 's/server/db migrate/g')"
```
Tested this on a hijacked card-connector container and it worked:
```
bash-5.0# APP_NAME='card-connector' APP_PACKAGE='uk.gov.pay.connector.app.ConnectorApp' ./migrate_database.sh
Creating task for app card-connector in org govuk-pay / 
Task has been submitted successfully for execution.
```