### PR TITLE
BAU Fix adminusers db migration script

### DIFF
--- a/ci/scripts/migrate_database.sh
+++ b/ci/scripts/migrate_database.sh
@@ -5,7 +5,7 @@ set -o errexit -o nounset
 : "${APP_PACKAGE:?APP_PACKAGE is required (e.g. uk.gov.pay.connector.ConnectorApplication)}"
 
 function createCommandFor() {
-  echo "source <(jq -r .\"start_command\" /home/vcap/staging_info.yml | sed 's/server/${1}/g')"
+  echo "source <(jq -r .\"start_command\" /home/vcap/staging_info.yml | sed 's/server/${1}/g' | sed 's/eval exec/eval/g')"
 }
 
 TASK_COMMAND=$(createCommandFor "db migrate")


### PR DESCRIPTION
When running db migrations we use `source` to modify & execute the start command directly
from the app's container to future proof against buildpack changes and the command
changing.

The app's start command is run with `exec` which replaces the process
that called it with a new process. This makes sense when you're starting the
app and want the app process to be pid 1 in the container.

When we're running migrations we want the command we've provided to `cf run-task`
to remain as pid 1 especially for adminusers where we effectively
run `initial migration && all other migrations`. Without this change the
initial migration runs and being pid 1 the container exits once its completed
and the next migration does not happen.

## WHAT ##
I've tested this on a hijacked adminusers db migration task and both the initial and subsequent migrations ran.
