### PR TITLE
PP-6724 Use default check frequency of 1m for pr resources

### DIFF
--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -558,7 +558,6 @@ resources:
     name: card-connector-pull-request
     type: pull-request
     icon: github
-    check_every: 1h
     source: &pull-request-source
       disable_forks: true
       repository: alphagov/pay-connector


### PR DESCRIPTION
Check for new prs and commits every 1m (this is the default frequency
for resources). The original value of 1h comes from our original
development of the pipeline before we added the auth credentials and
were much more restricted by api rate limit.

Github API rate limits for authenticated requests is
5000 per hour, we have 13 projects set-up so this will take 780 requests
per hour which leaves plenty of head room for the other calls to update statues
etc.