### PR TITLE
PP-6722: Update pipelines & tasks with pact-broker credentials

### DIFF
--- a/ci/pact_broker/pay-pact-broker_manifest.yml
+++ b/ci/pact_broker/pay-pact-broker_manifest.yml
@@ -12,8 +12,10 @@ applications:
     image: pactfoundation/pact-broker:2.54.0.0
   env:
     PACT_BROKER_PUBLIC_HEARTBEAT: "true"
-    PACT_BROKER_USERNAME: ((pact-broker-username))
-    PACT_BROKER_PASSWORD: ((pact-broker-password))
+    PACT_BROKER_BASIC_AUTH_USERNAME: ((pact-broker-username))
+    PACT_BROKER_BASIC_AUTH_PASSWORD: ((pact-broker-password))
+    PACT_BROKER_BASIC_AUTH_READ_ONLY_USERNAME: pay-team-ro
+    PACT_BROKER_BASIC_AUTH_READ_ONLY_PASSWORD: ((pact-broker-password))
   health-check-http-endpoint: /diagnostic/status/heartbeat
   health-check-type: http
   instances: 2

--- a/ci/pipelines/deploy.yml
+++ b/ci/pipelines/deploy.yml
@@ -12,6 +12,9 @@ definitions:
     task: verify-provider-with-consumer-master-pacts
     privileged: true
     file: omnibus/ci/tasks/pact-provider-master-verification.yml
+    vars: &pact-credentials
+      pact-broker-username: ((pact-broker-username))
+      pact-broker-password: ((pact-broker-password))
     params:
       consumer: change-this-value
       provider: change-this-value
@@ -414,6 +417,8 @@ jobs:
         trigger: true
       - task: tag-pacts-with-master
         file: omnibus/ci/tasks/tag-pacts-with-master.yml
+        vars:
+          <<: *pact-credentials
         params:
           consumer_name: frontend
       - task: calculate-release-number
@@ -456,6 +461,8 @@ jobs:
         trigger: true
       - task: tag-pacts-with-master
         file: omnibus/ci/tasks/tag-pacts-with-master.yml
+        vars:
+          <<: *pact-credentials
         params:
           consumer_name: products-ui
       - task: calculate-release-number
@@ -477,6 +484,8 @@ jobs:
         trigger: true
       - task: tag-pacts-with-master
         file: omnibus/ci/tasks/tag-pacts-with-master.yml
+        vars:
+          <<: *pact-credentials
         params:
           consumer_name: selfservice
       - task: calculate-release-number
@@ -570,6 +579,8 @@ jobs:
         trigger: true
       - task: tag-pacts-with-master
         file: omnibus/ci/tasks/tag-pacts-with-master.yml
+        vars:
+          <<: *pact-credentials
         params:
           consumer_name: publicapi
       - task: calculate-release-number
@@ -668,6 +679,8 @@ jobs:
         trigger: true
       - task: tag-pacts-with-master
         file: omnibus/ci/tasks/tag-pacts-with-master.yml
+        vars:
+          <<: *pact-credentials
         params:
           consumer_name: ledger
       - in_parallel:

--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -169,8 +169,13 @@ definitions:
   - &node-test
     task: test
     file: omnibus/ci/tasks/node-build-pr.yml
+  - x-pact-credentials: &pact-credentials
+    pact-broker-username: ((pact-broker-username))
+    pact-broker-password: ((pact-broker-password))
   - &publish-pacts
     task: publish pacts
+    vars:
+      <<: *pact-credentials
     params:
       consumer_name: updateThisValue
     file: omnibus/ci/tasks/publish-pacts.yml
@@ -283,12 +288,16 @@ definitions:
     task: pact verification
     privileged: true
     file: omnibus/ci/tasks/pact-provider-verification.yml
+    vars:
+      <<: *pact-credentials
     params:
       consumer: updateThisValue
       provider: updateThisValue
   - &pact-provider-test-preflight-check
     task: check is valid
     file: omnibus/ci/tasks/pact-provider-test-preflight-check.yml
+    vars:
+      <<: *pact-credentials
     params:
       consumer:
 

--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -170,8 +170,8 @@ definitions:
     task: test
     file: omnibus/ci/tasks/node-build-pr.yml
   - x-pact-credentials: &pact-credentials
-    pact-broker-username: ((pact-broker-username))
-    pact-broker-password: ((pact-broker-password))
+      pact-broker-username: ((pact-broker-username))
+      pact-broker-password: ((pact-broker-password))
   - &publish-pacts
     task: publish pacts
     vars:

--- a/ci/tasks/pact-provider-master-verification.yml
+++ b/ci/tasks/pact-provider-master-verification.yml
@@ -6,6 +6,8 @@ image_resource:
 params:
   consumer:
   provider:
+  broker-username: ((pact-broker-username))
+  broker-password: ((pact-broker-password))
 inputs:
   - name: src
 run:
@@ -30,6 +32,8 @@ run:
                                --version="$pr_sha" \
                                --pacticipant="$consumer" \
                                --latest="master" \
+                               --broker-username="$broker-username" \
+                               --broker-password="$broker-password" \
                                --broker_base_url='https://pay-concourse-pact-broker.cloudapps.digital'; then
         echo "Pacts are valid"
         exit 0;
@@ -44,5 +48,5 @@ run:
         -Dpact.provider.version="$pr_sha" \
         -Dpact.verifier.publishResults=true \
         -DPACT_BROKER_HOST=pay-concourse-pact-broker.cloudapps.digital \
-        -DPACT_BROKER_USERNAME=b \
-        -DPACT_BROKER_PASSWORD=a
+        -DPACT_BROKER_USERNAME="$broker-username" \
+        -DPACT_BROKER_PASSWORD="$broker-password"

--- a/ci/tasks/pact-provider-test-preflight-check.yml
+++ b/ci/tasks/pact-provider-test-preflight-check.yml
@@ -5,6 +5,8 @@ image_resource:
     repository: pactfoundation/pact-cli
 params:
   consumer:
+  broker-username: ((pact-broker-username))
+  broker-password: ((pact-broker-password))
 inputs:
   - name: src
 outputs:
@@ -19,7 +21,9 @@ run:
           git_sha="$(cat src/.git/resource/head_sha)"
           can_deploy="$(pact-broker can-i-deploy \
             --pacticipant="$consumer" --version="$git_sha" \
-            --broker_base_url='https://pay-concourse-pact-broker.cloudapps.digital')"
+            --broker_base_url='https://pay-concourse-pact-broker.cloudapps.digital')" \
+            --broker-username="$broker-username" \
+            --broker-password="$broker-password"
           return $?
       }
 

--- a/ci/tasks/pact-provider-verification.yml
+++ b/ci/tasks/pact-provider-verification.yml
@@ -7,6 +7,8 @@ image_resource:
 params:
   provider:
   consumer:
+  broker-username: ((pact-broker-username))
+  broker-password: ((pact-broker-password))
 inputs:
   - name: pact_params
   - name: test_target
@@ -54,5 +56,5 @@ run:
         -Dpact.provider.version="$provider_version" \
         -Dpact.verifier.publishResults=true \
         -DPACT_BROKER_HOST=pay-concourse-pact-broker.cloudapps.digital \
-        -DPACT_BROKER_USERNAME=b \
-        -DPACT_BROKER_PASSWORD=a
+        -DPACT_BROKER_USERNAME="$broker-username" \
+        -DPACT_BROKER_PASSWORD="$broker-password"

--- a/ci/tasks/publish-pacts.yml
+++ b/ci/tasks/publish-pacts.yml
@@ -8,6 +8,8 @@ inputs:
   - name: pacts
 params:
   consumer_name:
+  broker-username: ((pact-broker-username))
+  broker-password: ((pact-broker-password))
 run:
   path: sh
   args:
@@ -26,8 +28,10 @@ run:
         provider_name=$(jq .provider.name < "$pact" | tr -d '"')
         curl -v --fail -X PUT -H "Content-Type: application/json" \
         -d@"$pact" \
+        --user ${broker-username}:${broker-password} \
         https://pay-concourse-pact-broker.cloudapps.digital/pacts/provider/"${provider_name}"/consumer/"${consumer_name}"/version/"${version}"
         
         curl -v --fail -X PUT -H "Content-Type: application/json" \
+        --user ${broker-username}:${broker-password} \
         https://pay-concourse-pact-broker.cloudapps.digital/pacticipants/"${consumer_name}"/versions/"${version}"/tags/"${pr}"
       done

--- a/ci/tasks/tag-pacts-with-master.yml
+++ b/ci/tasks/tag-pacts-with-master.yml
@@ -7,6 +7,8 @@ inputs:
   - name: src
 params:
   consumer_name: selfservice
+  broker-username: ((pact-broker-username))
+  broker-password: ((pact-broker-password))
 run:
   path: sh
   dir: src
@@ -21,4 +23,5 @@ run:
 
       echo "tagging commits with with version ${pr_commit}"
       curl -v --fail -X PUT -H "Content-Type: application/json" \
+      --user ${broker-username}:${broker-password} \
       https://pay-concourse-pact-broker.cloudapps.digital/pacticipants/"${consumer_name}"/versions/"${pr_commit}"/tags/master


### PR DESCRIPTION
### What is it?
Updates deploy and pr pipelines to pass Pact broker credentials from Concourse secrets to pact tasks. Creds are passed as task "vars" which are interpolated into the task definition and mapped to broker-username & broker-password environment variables used in the task script.