### PR TITLE
Update deploy pipeline using new set-pipeline job step

### DIFF
--- a/ci/pipelines/deploy.yml
+++ b/ci/pipelines/deploy.yml
@@ -101,7 +101,7 @@ groups:
       - deploy-notifications-staging
       - deploy-toolbox-staging
       - deploy-sqs-staging
-      - update-pipeline
+      - update-deploy-pipeline
 
   - name: Smoke Tests
     jobs:
@@ -144,6 +144,15 @@ resources:
       uri: https://github.com/alphagov/pay-omnibus
       branch: master
 
+  - name: deploy-pipeline
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/alphagov/pay-omnibus
+      branch: master
+      paths:
+        - ci/pipelines/deploy.yml
+
   - name: every-10-minutes
     type: time
     icon: clock-outline
@@ -159,15 +168,6 @@ resources:
       space: staging
       username: ((paas-ireland-username))
       password: ((paas-ireland-password))
-
-  - name: deploy-pipeline
-    type: concourse-pipeline
-    icon: pipe
-    source:
-      teams:
-        - name: pay-deploy
-          username: pay-deploy
-          password: ((readonly_local_user_password))
 
   - name: carbon-relay-source
     type: git
@@ -394,16 +394,12 @@ x-cf-creds: &cf-creds
   CF_ORG: govuk-pay
 
 jobs:
-  - name: update-pipeline
+  - name: update-deploy-pipeline
     plan:
-      - get: omnibus
+      - get: deploy-pipeline
         trigger: true
-      - put: deploy-pipeline
-        params:
-          pipelines:
-            - name: deploy
-              team: pay-deploy
-              config_file: omnibus/ci/pipelines/deploy.yml
+      - set_pipeline: deploy
+        file: deploy-pipeline/ci/pipelines/deploy.yml
 
   # Build Jobs
   - name: build-card-frontend


### PR DESCRIPTION
We no longer need to use the update pipeline resource now
Concourse has a native method to update piplines on master merge.

I have added "git" resource to track changes on master to the
deploy.yaml pipeline. This ensures the update is only triggered
when the pipline is changed, rather than any file in the omnibus
repo.