### PR TITLE
PP-6722: Fix Pact broker authentication

### DIFF
--- a/ci/tasks/pact-provider-master-verification.yml
+++ b/ci/tasks/pact-provider-master-verification.yml
@@ -6,8 +6,8 @@ image_resource:
 params:
   consumer:
   provider:
-  broker-username: ((pact-broker-username))
-  broker-password: ((pact-broker-password))
+  broker_username: ((pact-broker-username))
+  broker_password: ((pact-broker-password))
 inputs:
   - name: src
 run:
@@ -32,8 +32,8 @@ run:
                                --version="$pr_sha" \
                                --pacticipant="$consumer" \
                                --latest="master" \
-                               --broker-username="$broker-username" \
-                               --broker-password="$broker-password" \
+                               --broker_username="$broker-username" \
+                               --broker_password="$broker-password" \
                                --broker_base_url='https://pay-concourse-pact-broker.cloudapps.digital'; then
         echo "Pacts are valid"
         exit 0;
@@ -48,5 +48,5 @@ run:
         -Dpact.provider.version="$pr_sha" \
         -Dpact.verifier.publishResults=true \
         -DPACT_BROKER_HOST=pay-concourse-pact-broker.cloudapps.digital \
-        -DPACT_BROKER_USERNAME="$broker-username" \
-        -DPACT_BROKER_PASSWORD="$broker-password"
+        -DPACT_BROKER_USERNAME="$broker_username" \
+        -DPACT_BROKER_PASSWORD="$broker_password"

--- a/ci/tasks/pact-provider-test-preflight-check.yml
+++ b/ci/tasks/pact-provider-test-preflight-check.yml
@@ -5,12 +5,14 @@ image_resource:
     repository: pactfoundation/pact-cli
 params:
   consumer:
-  broker-username: ((pact-broker-username))
-  broker-password: ((pact-broker-password))
+  broker_username: ((pact-broker-username))
+  broker_password: ((pact-broker-password))
 inputs:
   - name: src
 outputs:
   - name: pact_params
+caches:
+  - path: src/.m2
 run:
   path: sh
   args:
@@ -22,8 +24,8 @@ run:
           can_deploy="$(pact-broker can-i-deploy \
             --pacticipant="$consumer" --version="$git_sha" \
             --broker_base_url='https://pay-concourse-pact-broker.cloudapps.digital')" \
-            --broker-username="$broker-username" \
-            --broker-password="$broker-password"
+            --broker-username="$broker_username" \
+            --broker-password="$broker_password"
           return $?
       }
 

--- a/ci/tasks/pact-provider-verification.yml
+++ b/ci/tasks/pact-provider-verification.yml
@@ -7,8 +7,8 @@ image_resource:
 params:
   provider:
   consumer:
-  broker-username: ((pact-broker-username))
-  broker-password: ((pact-broker-password))
+  broker_username: ((pact-broker-username))
+  broker_password: ((pact-broker-password))
 inputs:
   - name: pact_params
   - name: test_target
@@ -56,5 +56,5 @@ run:
         -Dpact.provider.version="$provider_version" \
         -Dpact.verifier.publishResults=true \
         -DPACT_BROKER_HOST=pay-concourse-pact-broker.cloudapps.digital \
-        -DPACT_BROKER_USERNAME="$broker-username" \
-        -DPACT_BROKER_PASSWORD="$broker-password"
+        -DPACT_BROKER_USERNAME="$broker_username" \
+        -DPACT_BROKER_PASSWORD="$broker_password"

--- a/ci/tasks/tag-pacts-with-master.yml
+++ b/ci/tasks/tag-pacts-with-master.yml
@@ -23,5 +23,5 @@ run:
 
       echo "tagging commits with with version ${pr_commit}"
       curl -v --fail -X PUT -H "Content-Type: application/json" \
-      --user ${broker-username}:${broker-password} \
+      --user ${broker_username}:${broker_password} \
       https://pay-concourse-pact-broker.cloudapps.digital/pacticipants/"${consumer_name}"/versions/"${pr_commit}"/tags/master

--- a/ci/tasks/tag-pacts-with-master.yml
+++ b/ci/tasks/tag-pacts-with-master.yml
@@ -7,8 +7,8 @@ inputs:
   - name: src
 params:
   consumer_name: selfservice
-  broker-username: ((pact-broker-username))
-  broker-password: ((pact-broker-password))
+  broker_username: ((pact-broker-username))
+  broker_password: ((pact-broker-password))
 run:
   path: sh
   dir: src


### PR DESCRIPTION
Task params are used as bash environment variables so can't have underscores.