### PR TITLE
PP-6722: Add maven cache to Pact tasks

### DIFF
--- a/ci/tasks/pact-provider-master-verification.yml
+++ b/ci/tasks/pact-provider-master-verification.yml
@@ -10,6 +10,8 @@ params:
   broker_password: ((pact-broker-password))
 inputs:
   - name: src
+caches:
+  - path: src/.m2
 run:
   path: bash
   dir: src
@@ -40,6 +42,17 @@ run:
       fi
 
       start_docker
+
+      cat <<'EOF' >settings.xml
+      <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                                https://maven.apache.org/xsd/settings-1.0.0.xsd">
+            <localRepository>${env.MAVEN_REPO}</localRepository>
+      </settings>
+      EOF
+
+      export MAVEN_REPO="$PWD/.m2"
 
       mvn test \
         -DrunContractTests \

--- a/ci/tasks/pact-provider-verification.yml
+++ b/ci/tasks/pact-provider-verification.yml
@@ -12,6 +12,8 @@ params:
 inputs:
   - name: pact_params
   - name: test_target
+caches:
+  - path: test_target/.m2
 run:
   path: sh
   args:
@@ -48,6 +50,17 @@ run:
       provider_version="$(git rev-parse HEAD)"
 
       set +x
+
+      cat <<'EOF' >settings.xml
+      <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                                https://maven.apache.org/xsd/settings-1.0.0.xsd">
+            <localRepository>${env.MAVEN_REPO}</localRepository>
+      </settings>
+      EOF
+
+      export MAVEN_REPO="$PWD/.m2"
 
       mvn test \
         -DrunContractTests \

--- a/ci/tasks/publish-pacts.yml
+++ b/ci/tasks/publish-pacts.yml
@@ -8,8 +8,8 @@ inputs:
   - name: pacts
 params:
   consumer_name:
-  broker-username: ((pact-broker-username))
-  broker-password: ((pact-broker-password))
+  broker_username: ((pact-broker-username))
+  broker_password: ((pact-broker-password))
 run:
   path: sh
   args:
@@ -28,10 +28,10 @@ run:
         provider_name=$(jq .provider.name < "$pact" | tr -d '"')
         curl -v --fail -X PUT -H "Content-Type: application/json" \
         -d@"$pact" \
-        --user ${broker-username}:${broker-password} \
+        --user ${broker_username}:${broker_password} \
         https://pay-concourse-pact-broker.cloudapps.digital/pacts/provider/"${provider_name}"/consumer/"${consumer_name}"/version/"${version}"
         
         curl -v --fail -X PUT -H "Content-Type: application/json" \
-        --user ${broker-username}:${broker-password} \
+        --user ${broker_username}:${broker_password} \
         https://pay-concourse-pact-broker.cloudapps.digital/pacticipants/"${consumer_name}"/versions/"${version}"/tags/"${pr}"
       done


### PR DESCRIPTION
Pact tests run via maven require dependencies to be installed each time. The PR adds dependencies to the Concourse task cache which should save a couple of minutes from the build time.

Also fixes hyphens in env vars.