### PR TITLE
PP-6722 Fix typo

### DIFF
--- a/ci/tasks/pact-provider-test-preflight-check.yml
+++ b/ci/tasks/pact-provider-test-preflight-check.yml
@@ -26,7 +26,7 @@ run:
             --pacticipant="$consumer" --version="$git_sha" \
             --broker_base_url="$broker_url" \
             --broker-username="$broker_username" \
-            --broker-password="$broker_password"
+            --broker-password="$broker_password")"
           return $?
       }
 


### PR DESCRIPTION
Add the closing `)"` for the `can_deploy` call.


### WHAT ###
Checked it this time on hijacked container and ran `shellcheck` which was clean.
```
/tmp/build/a42abd17 # git_sha="$(cat src/.git/resource/head_sha)"
/tmp/build/a42abd17 # can_deploy="$(pact-broker can-i-deploy \
>   --pacticipant="$consumer" --version="$git_sha" \
>   --broker_base_url="$broker_url" \
>   --broker-username="$broker_username" \
>   --broker-password="$broker_password")"
/tmp/build/a42abd17 # echo $can_deploy
Computer says yes \o/ CONSUMER | C.VERSION | PROVIDER | P.VERSION | SUCCESS? ----------|--------------------------------|------------------------|--------------------------------|--------- publicapi | 318213a9803f7f3d341d18f2a08... | connector | eff61776768db58918a78c38776... | true publicapi | 318213a9803f7f3d341d18f2a08... | direct-debit-connector | a56c5797a078b3be3b47ec83744... | true publicapi | 318213a9803f7f3d341d18f2a08... | ledger | 46a8cc91439e6c5ad48388cf175... | true All required verification results are published and successful
```
