### PR TITLE
PP-6659 cloudfoundry_service_instance is an object

### DIFF
--- a/terraform/modules/paas/ledger.tf
+++ b/terraform/modules/paas/ledger.tf
@@ -9,7 +9,7 @@ resource "cloudfoundry_app" "ledger" {
   v3      = true
 
   service_binding {
-    service_instance = cloudfoundry_service_instance.splunk_log_service
+    service_instance = cloudfoundry_service_instance.splunk_log_service.id
   }
 
   lifecycle {

--- a/terraform/modules/paas/selfservice.tf
+++ b/terraform/modules/paas/selfservice.tf
@@ -9,7 +9,7 @@ resource "cloudfoundry_app" "selfservice" {
   v3      = true
 
   service_binding {
-    service_instance = cloudfoundry_service_instance.splunk_log_service
+    service_instance = cloudfoundry_service_instance.splunk_log_service.id
   }
 
   lifecycle {


### PR DESCRIPTION
When setting the `service_instance`  for `cloudfoundry_app` it needs the GUID from
`cloudfoundry_service_instance` which is an object. This change has
already been made elsewhere, seems these were missed.