### PR TITLE
BAU Put broker_url in double quotes to permit parameter expansion

### DIFF
--- a/ci/tasks/pact-provider-master-verification.yml
+++ b/ci/tasks/pact-provider-master-verification.yml
@@ -37,7 +37,7 @@ run:
                                --latest="master" \
                                --broker_username="$broker_username" \
                                --broker_password="$broker_password" \
-                               --broker_base_url='${broker_url}'; then
+                               --broker_base_url="${broker_url}"; then
         echo "Pacts are valid"
         exit 0;
       fi


### PR DESCRIPTION
### WHAT ###
single quotes prevent parameter expansion so change them to `"` so it will work as intended. Tested on hijacked container
```
bash-5.0# pact-broker can-i-deploy --pacticipant="$provider"           --version="$pr_sha"           --pacticipant="$consumer"           --latest="master"           --broker_username="$broker_username"           --broker_password="$broker_password"           --broker_base_url="${broker_url}"
Computer says yes \o/
There are no missing dependencies
```