### PR TITLE
PP-6823 Add pay-java-commons to pr pipeline

### DIFF
--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -387,6 +387,10 @@ groups:
     jobs:
       - toolbox-test
 
+  - name: Java-Commons
+    jobs:
+      - java-commons-test
+
   - name: Update-Pipeline
     jobs:
       - update-pr-ci-pipeline
@@ -586,6 +590,12 @@ resources:
     source:
       <<: *pull-request-source
       repository: alphagov/pay-endtoend
+
+  - <<: *pull-request
+    name: java-commons-pull-request
+    source:
+      <<: *pull-request-source
+      repository: alphagov/pay-java-commons
 
   - <<: *pull-request
     name: adminusers-pull-request
@@ -927,6 +937,53 @@ jobs:
         put: publicapi-pull-request
 
   - <<: *job-definition
+    name: java-commons-test
+    plan:
+    - <<: *get-pull-request
+      resource: java-commons-pull-request
+    - <<: *get-omnibus
+    - <<: *put-integration-test-pending-status
+      put: java-commons-pull-request
+    - task: test
+      config:
+        container_limits: {}
+        image_resource:
+          type: registry-image
+          source:
+            repository: maven
+            tag: 3.6.1
+        caches:
+          - path: src/.m2
+        inputs:
+          - name: src
+        platform: linux
+        run:
+          path: bash
+          dir: src
+          args:
+          - -ec
+          - |
+            export MAVEN_HOME=/usr/lib/mvn
+            export PATH=$MAVEN_HOME/bin:$PATH
+            export MAVEN_REPO="$PWD/.m2"
+
+            cat <<'EOF' >settings.xml
+            <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                                      https://maven.apache.org/xsd/settings-1.0.0.xsd">
+                  <localRepository>${env.MAVEN_REPO}</localRepository>
+            </settings>
+            EOF
+
+            mvn --global-settings settings.xml clean install
+      on_failure:
+        <<: *put-integration-test-failed-status
+        put: java-commons-pull-request
+    - <<: *put-integration-test-success-status
+      put: java-commons-pull-request
+
+  - <<: *job-definition
     name: adminusers-unit-test
     plan:
     - <<: *get-pull-request
@@ -960,7 +1017,7 @@ jobs:
         consumer_name: adminusers
     - <<: *put-integration-test-success-status
       put: adminusers-pull-request
-      
+
   - <<: *job-definition
     name: adminusers-pact-provider-test
     plan:


### PR DESCRIPTION
Runs mvn clean install as per current Jenkinsfile.

## HOW TO TEST ##
Set this config on our pr pipeline and the new job passes: https://cd.gds-reliability.engineering/teams/pay-deploy/pipelines/pr-ci/jobs/java-commons-test/builds/1

## WHAT ##
Probably scope to align some of the mvn task definitions but this one has been inlined since it is the only one to use `install` phase.