### PR TITLE
BAU Fix pact broker host var when running mvn test

### DIFF
--- a/ci/tasks/pact-provider-master-verification.yml
+++ b/ci/tasks/pact-provider-master-verification.yml
@@ -61,6 +61,6 @@ run:
         -DPACT_CONSUMER_TAG="master" \
         -Dpact.provider.version="$pr_sha" \
         -Dpact.verifier.publishResults=true \
-        -DPACT_BROKER_HOST=${broker_url} \
+        -DPACT_BROKER_HOST="${broker_url#https://}" \
         -DPACT_BROKER_USERNAME="$broker_username" \
         -DPACT_BROKER_PASSWORD="$broker_password"


### PR DESCRIPTION
The java pact tests require a host rather than url for the pact broker
so remove the `https://` from the beginning.

## WHAT ##
Tested this on a hijacked container and it works.