### PR TITLE
PP-6832 Stop containers used for e2e

### DIFF
--- a/ci/tasks/endtoend/task.yml
+++ b/ci/tasks/endtoend/task.yml
@@ -101,7 +101,6 @@ run:
       ;;
     esac
 
-
-
+    docker-compose down
 
     exit 0


### PR DESCRIPTION
We effectively run `docker system prune -af --volumes` when the e2e task
exists via a trap. However we're not stopping the containers used in the
e2e tests so they're not pruned when that is run. This leaves the
containers and images hanging around. If we stop the containers before
running `docker system prune` it should clear them all out and free up
more disk quicker.

## WHAT ##
I've tested this idea on a hijacked container. The `docker system prune -af --volumes` that ran as part of the task exiting only reclaimed 961MB and seemed to be due to pruning the images that are not part of that directdebit e2e scenario and so wouldn't have been running. https://cd.gds-reliability.engineering/teams/pay-deploy/pipelines/pr-ci/jobs/directdebit-frontend-test/builds/41#L5f186f35:326

Hijacking the container and running the `docker system prune -af` a second time, once all containers had been stopped reclaimed the full 3.79GB and no images remained.
```
Total reclaimed space: 3.79GB
bash-5.0# docker image ls
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
```

By running `docker-compose down` it should stop all containers which were originally started with the `docker-compose up` so when we prune it'll reap everything as we intend.