### PR TITLE
PP-6832 Stop docker containers in clean up trap

### DIFF
--- a/ci/tasks/endtoend/task.yml
+++ b/ci/tasks/endtoend/task.yml
@@ -44,6 +44,7 @@ run:
 
     function cleanup {
       echo "CLEANUP TRIGGERED"
+      docker stop $(docker ps -q)
       clean_docker
       stop_docker
       echo "CLEANUP COMPLETE"


### PR DESCRIPTION
`docker-compose down` will stop running containers if the tests succeed
but if they fail and the trap is triggered before that line then `docker
stop $(docker ps -q)` will stop them before the `docker system prune`
runs.