### PR TITLE
PP-6854 Remove name field from steps

### DIFF
--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -9,12 +9,10 @@ definitions:
     resource: updateThisValue
     trigger: true
     version: every
-    name: src
   - &get-omnibus
     get: omnibus
     resource: omnibus
     trigger: false
-    name: omnibus
   - &put-unit-tests-pending-status
     put: updateThisValue
     params:


### PR DESCRIPTION
It appears that `name` is no longer a valid field within the `step`
schema, see: https://concourse-ci.org/jobs.html#schema.step. This change
fixed the pipeline so it passes `fly validate-pipeline`.

##WHAT##
```
gds5062:pay-omnibus danworth$ fly validate-pipeline  -c ci/pipelines/pr.yml
looks good
```
