### PR TITLE
PP-6883 Remove Notify Base URL

### DIFF
--- a/terraform/staging-paas/terraform.tfvars
+++ b/terraform/staging-paas/terraform.tfvars
@@ -42,7 +42,6 @@ credentials = {
       epdq_live_url = "https://example.com/stub/epdq"
       epdq_test_url = "https://example.com/stub/epdq"
       sqs_enabled = "true"
-      notify_base_url = "https://example.com/notify"
       stripe_transaction_fee_percentage = "0.1"
       card_connector_analytics_tracking_id = "testing-123"
     }


### PR DESCRIPTION
- Connector no longer needs a base URL in the secret service as it is no
longer retrieved from there.