### PR TITLE
PP-6917 Add memory limit for e2e tasks

### DIFF
--- a/ci/tasks/endtoend/task.yml
+++ b/ci/tasks/endtoend/task.yml
@@ -28,6 +28,8 @@ inputs:
 params:
   app_name:
   test_type:
+  END_TO_END_JAVA_OPTS: '-Xms1G -Xmx2G'
+  END_TO_END_MEM_LIMIT: '5G'
 
 run:
   path: bash


### PR DESCRIPTION
Set the same memory limits for e2e container and JVM as we currently do on
Jenkins.

## WHAT ##
Appears we set these values on Jenkins here: https://github.com/alphagov/pay-scripts/blob/b5e643eb2ee353a2be482797535efb0747d99942/jenkins/ruby-scripts/pay-environment.rb#L8

We've seen occasions on concourse ci when we exhaust worker memory and the OOM killer kicks in. Seems prudent to introduce similar memory limits for e2e and see what impact this has.