### PR TITLE
PP-6934 Run e2e on Java apps serially

### DIFF
--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -732,6 +732,7 @@ jobs:
 
   - <<: *job-definition
     name: card-connector-card-e2e
+    serial: true
     plan:
       - <<: *get-pull-request
         resource: card-connector-pull-request
@@ -758,6 +759,7 @@ jobs:
 
   - <<: *job-definition
     name: endtoend-products-e2e
+    serial: true
     plan:
       - <<: *get-pull-request
         resource: endtoend-pull-request
@@ -783,6 +785,7 @@ jobs:
 
   - <<: *job-definition
     name: endtoend-card-e2e
+    serial: true
     plan:
       - <<: *get-pull-request
         resource: endtoend-pull-request
@@ -843,6 +846,7 @@ jobs:
 
   - <<: *job-definition
     name: publicapi-card-e2e
+    serial: true
     plan:
       - <<: *get-pull-request
         resource: publicapi-pull-request
@@ -911,6 +915,7 @@ jobs:
 
   - <<: *job-definition
     name: publicapi-products-e2e
+    serial: true
     plan:
       - <<: *get-pull-request
         resource: publicapi-pull-request
@@ -1039,6 +1044,7 @@ jobs:
 
   - <<: *job-definition
     name: adminusers-card-e2e
+    serial: true
     plan:
       - <<: *get-pull-request
         resource: adminusers-pull-request
@@ -1100,6 +1106,7 @@ jobs:
 
   - <<: *job-definition
     name: cardid-card-e2e
+    serial: true
     plan:
       - <<: *get-pull-request
         resource: cardid-pull-request
@@ -1294,6 +1301,7 @@ jobs:
 
   - <<: *job-definition
     name: ledger-card-e2e
+    serial: true
     plan:
       - <<: *get-pull-request
         resource: ledger-pull-request
@@ -1355,6 +1363,7 @@ jobs:
 
   - <<: *job-definition
     name: publicauth-card-e2e
+    serial: true
     plan:
       - <<: *get-pull-request
         resource: publicauth-pull-request
@@ -1437,6 +1446,7 @@ jobs:
 
   - <<: *job-definition
     name: products-products-e2e
+    serial: true
     plan:
       - <<: *get-pull-request
         resource: products-pull-request


### PR DESCRIPTION
This is to try and protect worker memory which is currently easily
exhausted if mulitple prs are raised concurrently. Java apps takes
approximately 11GB at their peak since unit, pact, intergration and e2e
overlap.

This won't offer total protection since it won't protect the worker
limits if multiple prs are raised across mulitiple apps.

This should likely be replaced with some kind of autoscaling solution/
provisioning of extra worker capacity. We are also planning to make e2e
optional on PRs.

## WHAT ##
Docs on `serial`
https://concourse-ci.org/jobs.html#schema.job.serial
which takes precedence over the existing `max_in_flight` setting
https://concourse-ci.org/jobs.html#schema.job.max_in_flight

```
GDS5062:pay-omnibus danworth$ fly -t pay-dev validate-pipeline -c ci/pipelines/pr.yml
looks good
```
