### PR TITLE
PP-6966 Remove auto trigger for adminusers card e2e

### DIFF
--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -1047,6 +1047,7 @@ jobs:
     serial: true
     plan:
       - <<: *get-pull-request
+        trigger: false
         resource: adminusers-pull-request
         passed: [adminusers-unit-test]
       - <<: *get-omnibus


### PR DESCRIPTION
We want e2e to be optional on prs. To run this from now on pin the
correct version in the adminusers pr resource and manually hit "build"
(or use `fly`).

```
gds5062:pay-omnibus danworth$ fly validate-pipeline -c ci/pipelines/pr.yml
looks good
```