### PR TITLE
Pp 6996 fix pay stubs ci

### DIFF
--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -449,6 +449,7 @@ groups:
   - name: Stubs
     jobs:
       - stubs-test
+      - record-stubs-build-time
 
 resource_types:
   - name: pull-request
@@ -2052,6 +2053,14 @@ jobs:
         put: stubs-pull-request
     - <<: *put-test-success-status
       put: stubs-pull-request
+
+  - <<: *job-definition
+    name: record-stubs-build-time
+    plan:
+    - <<: *get-pull-request
+      resource: stubs-pull-request
+      passed: [stubs-test]
+    - <<: *send-pr-build-time
 
   - name: update-pr-ci-pipeline
     plan:

--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -2029,7 +2029,24 @@ jobs:
     - <<: *get-omnibus
     - <<: *put-test-pending-status
       put: stubs-pull-request
-    - <<: *node-test
+    - task: run tests
+      config:
+        platform: linux
+        image_resource:
+          type: registry-image
+          source:
+            repository: node
+            tag: 12-stretch
+        inputs:
+          - name: src
+        run:
+          path: sh
+          dir: src
+          args:
+            - -ec
+            - |
+              npm ci
+              npm test
       on_failure:
         <<: *put-test-failed-status
         put: stubs-pull-request


### PR DESCRIPTION
Pay stubs only needs install and tests running.

## WHAT ##
Rather than make `node-build-pr.yml` any more complicated with conditional logic for pay-stubs just inline the simple task to install and test.

Also add recording of pr build time whilst we're here.