### PR TITLE
BAU: Bind carbon-relay and metric-exporter to correct log service

### DIFF
--- a/terraform/modules/paas/carbon-relay.tf
+++ b/terraform/modules/paas/carbon-relay.tf
@@ -8,8 +8,8 @@ resource "cloudfoundry_app" "carbon-relay" {
   stopped = true
   v3      = true
 
-  service_binding { 
-    service_instance = cloudfoundry_service_instance.cde_splunk_log_service.id
+  service_binding {
+    service_instance = cloudfoundry_service_instance.splunk_log_service.id
   }
 
   lifecycle {
@@ -28,7 +28,7 @@ resource "cloudfoundry_route" "carbon_relay" {
 }
 
 module "carbon_relay_credentials" {
-  source = "../credentials"
+  source               = "../credentials"
   pay_low_pass_secrets = lookup(local.carbon_relay_credentials, "pay_low_pass_secrets")
 }
 

--- a/terraform/modules/paas/metric-exporter.tf
+++ b/terraform/modules/paas/metric-exporter.tf
@@ -8,8 +8,8 @@ resource "cloudfoundry_app" "metric_exporter" {
   stopped = true
   v3      = true
 
-  service_binding { 
-    service_instance = cloudfoundry_service_instance.cde_splunk_log_service.id
+  service_binding {
+    service_instance = cloudfoundry_service_instance.splunk_log_service.id
   }
 
   lifecycle {
@@ -18,7 +18,7 @@ resource "cloudfoundry_app" "metric_exporter" {
 }
 
 module "metric_exporter_credentials" {
-  source = "../credentials"
+  source               = "../credentials"
   pay_low_pass_secrets = lookup(local.metric_exporter_credentials, "pay_low_pass_secrets")
 }
 


### PR DESCRIPTION
Binds metric exporter and carbon relay to Splunk log service in "non-cde" space.