### PR TITLE
PP-6914: Add VPC to AWS environments

### DIFF
--- a/terraform/modules/aws/card-connector.tf
+++ b/terraform/modules/aws/card-connector.tf
@@ -1,11 +1,10 @@
 resource "aws_iam_user" "card_connector" {
-  name = "card.connector"
+  name          = "card.connector"
   force_destroy = true
-} 
+}
 
-resource "aws_iam_group_membership" "card_connector_applications_group_membership" {
-  name   = "applications_group_membership"
-  user   = aws_iam_user.card_connector.name]
+resource "aws_iam_user_group_membership" "card_connector_group_membership" {
+  user   = aws_iam_user.card_connector.name
   groups = [aws_iam_group.applications.name]
 }
 

--- a/terraform/modules/aws/ledger.tf
+++ b/terraform/modules/aws/ledger.tf
@@ -1,9 +1,8 @@
 resource "aws_iam_user" "ledger" {
-  name  = "ledger"
-} 
+  name = "ledger"
+}
 
-resource "aws_iam_user_group_membership" "ledger_applications_group_membership" {
-  name   = "applications_group_membership"
+resource "aws_iam_user_group_membership" "ledger_group_membership" {
   user   = aws_iam_user.ledger.name
   groups = [aws_iam_group.applications.name]
 }

--- a/terraform/modules/aws/variables.tf
+++ b/terraform/modules/aws/variables.tf
@@ -14,6 +14,12 @@ variable "paas_domain" {
 }
 
 variable "paas_public_ips" {
-  type = list
-  default = [ "52.208.24.161", "52.208.1.143", "52.51.250.21" ]
+  type    = list
+  default = ["52.208.24.161", "52.208.1.143", "52.51.250.21"]
+}
+
+variable "vpc_cidr" {
+  type        = string
+  description = "The default VPC cidr range for this environment. This may differ between environments to support VPC peering without overlapping ranges."
+  default     = "172.16.0.0/16"
 }

--- a/terraform/modules/aws/vpc.tf
+++ b/terraform/modules/aws/vpc.tf
@@ -1,0 +1,27 @@
+data "aws_availability_zones" "available" {}
+
+resource "aws_vpc" "default" {
+  cidr_block = var.vpc_cidr
+
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Name = "${var.environment}-vpc"
+  }
+}
+
+resource "aws_route_table" "default" {
+  vpc_id = aws_vpc.default.id
+
+  tags = {
+    Name = "${var.environment}-route"
+  }
+}
+
+resource "aws_default_security_group" "default" {
+  vpc_id = aws_vpc.default.id
+
+  # Omitting all ingress {} and egress {} blocks to deny by default.
+  # Nothing should use this security group, but it cannot be deleted.
+}

--- a/terraform/staging-aws/site.tf
+++ b/terraform/staging-aws/site.tf
@@ -40,7 +40,8 @@ module "staging" {
     pass.low-pass = pass.low-pass
   }
 
-  environment         = "staging"
-  domain_name         = "gdspay.uk"
-  paas_domain         = "cloudapps.digital"
+  environment = "staging"
+  domain_name = "gdspay.uk"
+  paas_domain = "cloudapps.digital"
+  vpc_cidr    = "172.20.0.0/16"
 }


### PR DESCRIPTION
### What is it?

 - Adds a default VPC with relevant configuration.
 - Allows VPC CIDR range to configured per-environment to support VPC peering without overlapping ranges.
 - Configures the default security group with null settings
 - Adds a default route table

 - Various formatting fixes 🧹 