### PR TITLE
PP-6914: Only allow staging TF to be applied in staging AWS account

### DIFF
--- a/terraform/staging-account/site.tf
+++ b/terraform/staging-account/site.tf
@@ -9,6 +9,8 @@ terraform {
 provider "aws" {
   version = "~> 2.0"
   region  = "eu-west-2"
+
+  allowed_account_ids = ["234617505259"]
 }
 
 resource "aws_s3_bucket" "tfstate" {
@@ -39,4 +41,10 @@ resource "aws_s3_bucket_public_access_block" "tfstate" {
   block_public_policy     = true
   ignore_public_acls      = true
   restrict_public_buckets = true
+}
+
+module "cyber_security_audit_role" {
+  source = "git::https://github.com/alphagov/tech-ops//cyber-security/modules/gds_security_audit_role?ref=13f54e554b8f56f34f975447a1011a03321c92b6"
+
+  chain_account_id = "988997429095"
 }

--- a/terraform/staging-aws/site.tf
+++ b/terraform/staging-aws/site.tf
@@ -9,12 +9,16 @@ terraform {
 provider "aws" {
   version = "~> 2.0"
   region  = "eu-west-2"
+
+  allowed_account_ids = ["234617505259"]
 }
 
 provider "aws" {
   version = "~> 2.0"
   region  = "us-east-1"
   alias   = "us"
+
+  allowed_account_ids = ["234617505259"]
 }
 
 provider "pass" {


### PR DESCRIPTION
Ensures AWS Terraform provider declared in staging AWS infra may only be applied in the staging AWS account. This helps prevent the accidental application of changes in the wrong environment.

Also enables Cyber security's cross-account audit role