### PR TITLE
BAU: Update cyber security audit role to TF 0.12 compatible module

### DIFF
--- a/terraform/staging-account/site.tf
+++ b/terraform/staging-account/site.tf
@@ -44,7 +44,7 @@ resource "aws_s3_bucket_public_access_block" "tfstate" {
 }
 
 module "cyber_security_audit_role" {
-  source = "git::https://github.com/alphagov/tech-ops//cyber-security/modules/gds_security_audit_role?ref=13f54e554b8f56f34f975447a1011a03321c92b6"
+  source = "git::https://github.com/alphagov/tech-ops//cyber-security/modules/gds_security_audit_role?ref=720885a9769c40942ff30b32179e1fad18f2ca10"
 
   chain_account_id = "988997429095"
 }

--- a/terraform/test-account/site.tf
+++ b/terraform/test-account/site.tf
@@ -22,7 +22,7 @@ module "state_bucket" {
 }
 
 module "cyber_security_audit_role" {
-  source = "git::https://github.com/alphagov/tech-ops//cyber-security/modules/gds_security_audit_role?ref=13f54e554b8f56f34f975447a1011a03321c92b6"
+  source = "git::https://github.com/alphagov/tech-ops//cyber-security/modules/gds_security_audit_role?ref=720885a9769c40942ff30b32179e1fad18f2ca10"
 
   chain_account_id = "988997429095"
 }


### PR DESCRIPTION
Updates Cyber security AWS account audit TF module to TF 0.12 compatible module.

See commit: https://github.com/alphagov/tech-ops/commit/720885a9769c40942ff30b32179e1fad18f2ca10