### PR TITLE
BAU: upgrade all Terraform to use AWS provider v3

### DIFF
--- a/terraform/modules/aws/cloudfront_logging/main.tf
+++ b/terraform/modules/aws/cloudfront_logging/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 2.0"
+  version = "~> 3.0"
   region  = "us-east-1"
   alias   = "us"
 }

--- a/terraform/modules/aws/route53.tf
+++ b/terraform/modules/aws/route53.tf
@@ -19,16 +19,25 @@ resource "aws_acm_certificate" "cert" {
 }
 
 resource "aws_route53_record" "cert_validation" {
-  name    = aws_acm_certificate.cert.domain_validation_options.0.resource_record_name
-  type    = aws_acm_certificate.cert.domain_validation_options.0.resource_record_type
-  zone_id = data.aws_route53_zone.root.id
-  records = [aws_acm_certificate.cert.domain_validation_options.0.resource_record_value]
-  ttl     = 60
+  for_each = {
+    for dvo in aws_acm_certificate.cert.domain_validation_options : dvo.domain_name => {
+      name    = dvo.resource_record_name
+      record  = dvo.resource_record_value
+      type    = dvo.resource_record_type
+      zone_id = data.aws_route53_zone.root.id
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  type            = each.value.type
+  zone_id         = each.value.zone_id
+  records         = [each.value.record]
+  ttl             = 60
 }
 
 resource "aws_acm_certificate_validation" "cert" {
-  provider = aws.us
-
+  provider                = aws.us
   certificate_arn         = aws_acm_certificate.cert.arn
-  validation_record_fqdns = [aws_route53_record.cert_validation.fqdn]
+  validation_record_fqdns = [for record in aws_route53_record.cert_validation : record.fqdn]
 }

--- a/terraform/modules/aws/waf_logging/main.tf
+++ b/terraform/modules/aws/waf_logging/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 2.0"
+  version = "~> 3.0"
   region  = "us-east-1"
   alias   = "us"
 }

--- a/terraform/staging-account/site.tf
+++ b/terraform/staging-account/site.tf
@@ -7,7 +7,7 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 2.0"
+  version = "~> 3.0"
   region  = "eu-west-2"
 
   allowed_account_ids = ["234617505259"]

--- a/terraform/staging-aws/site.tf
+++ b/terraform/staging-aws/site.tf
@@ -7,7 +7,7 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 2.0"
+  version = "~> 3.0"
   region  = "eu-west-2"
 
   allowed_account_ids = ["234617505259"]

--- a/terraform/staging-aws/site.tf
+++ b/terraform/staging-aws/site.tf
@@ -14,7 +14,7 @@ provider "aws" {
 }
 
 provider "aws" {
-  version = "~> 2.0"
+  version = "~> 3.0"
   region  = "us-east-1"
   alias   = "us"
 

--- a/terraform/staging-paas/site.tf
+++ b/terraform/staging-paas/site.tf
@@ -18,7 +18,7 @@ provider "cloudfoundry" {
 }
 
 provider "aws" {
-  version = "~> 2.0"
+  version = "~> 3.0"
   region  = "eu-west-2"
 }
 

--- a/terraform/test-account/site.tf
+++ b/terraform/test-account/site.tf
@@ -10,7 +10,7 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 2.0"
+  version = "~> 3.0"
   region  = "eu-west-1"
 
   allowed_account_ids = ["734876687119"]


### PR DESCRIPTION
The v3 AWS Terraform provider was released in July 2020. 

See changelog: https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md

The only breaking changes were related to the `aws_route53_record` resource. I have applied this to the staging environment successfully.