### PR TITLE
PP-7013 Add main pipeline

### DIFF
--- a/ci/pipelines/deploy.yml
+++ b/ci/pipelines/deploy.yml
@@ -29,7 +29,6 @@ groups:
 
   - name: Card Connector
     jobs:
-      - build-card-connector
       - deploy-card-connector-staging
       - migrate-card-connector-db-staging
       - card-payment-smoke-tests-staging
@@ -219,12 +218,6 @@ resources:
     source:
       <<: *git-repo-source
       uri: https://github.com/alphagov/pay-direct-debit-connector
-
-  - <<: *git-repo
-    name: card-connector-source
-    source:
-      <<: *git-repo-source
-      uri: https://github.com/alphagov/pay-connector
 
   - <<: *git-repo
     name: publicapi-source
@@ -529,44 +522,6 @@ jobs:
         params: 
           <<: *release-params
 
-  - name: build-card-connector
-    plan:
-      - get: omnibus
-      - get: src
-        resource: card-connector-source
-        trigger: true
-      - in_parallel:
-        - <<: *verify-provider-with-consumer
-          task: verify-with-publicapi
-          params:
-            consumer: publicapi
-            provider: connector
-        - <<: *verify-provider-with-consumer
-          task: verify-with-frontend
-          params:
-            consumer: frontend
-            provider: connector
-        - <<: *verify-provider-with-consumer
-          task: verify-with-selfservice
-          params:
-            consumer: selfservice
-            provider: connector
-        - <<: *verify-provider-with-consumer
-          task: verify-with-ledger
-          params:
-            consumer: ledger
-            provider: connector
-      - task: calculate-release-number
-        file: omnibus/ci/tasks/calculate-release-number.yml
-      - task: build-app
-        file: omnibus/ci/tasks/maven-build.yml
-        params:
-          APP_NAME: pay-connector
-      - put: release
-        resource: git-card-connector-pre-release
-        params: 
-          <<: *release-params
-
   - name: build-publicapi
     plan:
       - get: omnibus
@@ -801,11 +756,35 @@ jobs:
     plan:
       - get: omnibus
       - get: git-card-connector-pre-release
-        passed: [build-card-connector]
         trigger: true
       - task: extract-card-connector-artefact
         file: omnibus/ci/tasks/extract-artefact.yml
         input_mapping: { git-release: git-card-connector-pre-release }
+      - in_parallel:
+        - <<: *verify-provider-with-consumer
+          task: verify-with-publicapi
+          input_mapping: {src: extract-card-connector-artefact}
+          params:
+            consumer: publicapi
+            provider: connector
+        - <<: *verify-provider-with-consumer
+          task: verify-with-frontend
+          input_mapping: {src: extract-card-connector-artefact}
+          params:
+            consumer: frontend
+            provider: connector
+        - <<: *verify-provider-with-consumer
+          task: verify-with-selfservice
+          input_mapping: {src: extract-card-connector-artefact}
+          params:
+            consumer: selfservice
+            provider: connector
+        - <<: *verify-provider-with-consumer
+          task: verify-with-ledger
+          input_mapping: {src: extract-card-connector-artefact}
+          params:
+            consumer: ledger
+            provider: connector
       - task: deploy-to-paas-staging
         file: omnibus/ci/tasks/cf-v3-deploy.yml
         params:

--- a/ci/pipelines/main.yml
+++ b/ci/pipelines/main.yml
@@ -1,0 +1,76 @@
+definitions:
+  - &job-definition
+    name: updateThisValue
+    serial: true
+    build_log_retention:
+      builds: 500
+
+  - &github-release-source
+    source:
+      owner: alphagov
+      access_token: ((github-access-token))
+      tag_filter: "paas_release-(.*)"
+      order_by: version
+      repository: update-this-value
+      pre_release: true
+      release: false
+
+  - &release-params
+    params:
+      name: release-info/name
+      tag: release-info/name
+      globs:
+        - build-output/*
+      commitish: src/.git/ref
+
+groups:
+  - name: card-connector
+    jobs:
+      - build-card-connector
+
+resource_types:
+  - name: pull-request
+    type: registry-image
+    source:
+      repository: teliaoss/github-pr-resource
+      tag: dev
+
+resources:
+  - name: card-connector-main
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/alphagov/pay-connector
+      branch: master
+  - name: git-card-connector-pre-release
+    type: github-release
+    source:
+      <<: *github-release-source
+      repository: pay-connector
+  - name: omnibus
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/alphagov/pay-omnibus
+      branch: master
+      username: alphagov-pay-ci
+      password: ((github-access-token))
+
+jobs:
+  - <<: *job-definition
+    name: build-card-connector
+    plan:
+      - get: omnibus
+      - get: src
+        resource: card-connector-main
+        trigger: true
+      - task: calculate-release-number
+        file: omnibus/ci/tasks/calculate-release-number.yml
+      - task: build-app
+        file: omnibus/ci/tasks/maven-build.yml
+        params:
+          APP_NAME: pay-connector
+      - put: release
+        resource: git-card-connector-pre-release
+        params:
+          <<: *release-params


### PR DESCRIPTION
Initial work on adding main pipeline which will eventually build, test
and create github releases for the main branch.

Changes included here:
- Build connector when a commit to main branch is made
- Upload github release
- Remove building of connector release from existing `deploy` pipeline
- Trigger deploying connector to staging via the github release rather than a
  commit to main branch. Once we have test environment this trigger
  should use a tag_filter that includes the word "test" to only trigger
  after deploys have successfully deployed to test.
- Run pact provider verification as part of the deploy job in the deploy
  pipeline.