### PR TITLE
PP-6914: Add RDS subnets and PaaS VPC ingress

### DIFF
--- a/terraform/modules/aws/rds.tf
+++ b/terraform/modules/aws/rds.tf
@@ -1,0 +1,11 @@
+data "aws_availability_zones" "available" {}
+
+module "rds" {
+  source = "./rds"
+
+  environment    = var.environment
+  vpc_id         = aws_vpc.default.id
+  vpc_cidr       = aws_vpc.default.cidr_block
+  route_table_id = aws_route_table.default.id
+  base_subnet    = var.subnet_reservations.rds
+}

--- a/terraform/modules/aws/rds.tf
+++ b/terraform/modules/aws/rds.tf
@@ -3,9 +3,10 @@ data "aws_availability_zones" "available" {}
 module "rds" {
   source = "./rds"
 
-  environment    = var.environment
-  vpc_id         = aws_vpc.default.id
-  vpc_cidr       = aws_vpc.default.cidr_block
-  route_table_id = aws_route_table.default.id
-  base_subnet    = var.subnet_reservations.rds
+  environment     = var.environment
+  vpc_id          = aws_vpc.default.id
+  vpc_cidr        = aws_vpc.default.cidr_block
+  route_table_id  = aws_route_table.default.id
+  base_subnet     = var.subnet_reservations.rds
+  permitted_cidrs = [var.paas_ireland_cidr]
 }

--- a/terraform/modules/aws/rds/subnets.tf
+++ b/terraform/modules/aws/rds/subnets.tf
@@ -19,3 +19,24 @@ resource "aws_route_table_association" "rds_subnet" {
   subnet_id      = each.value.id
   route_table_id = var.route_table_id
 }
+
+resource "aws_security_group" "application_rds" {
+  name        = "${var.environment}-sg-rds"
+  description = "${var.environment} RDS database security group"
+  vpc_id      = var.vpc_id
+
+  tags = {
+    Name = "${var.environment}-sg-rds"
+  }
+}
+
+resource "aws_security_group_rule" "permit_postgres_from_paas_to_rds" {
+  type     = "ingress"
+  protocol = "tcp"
+
+  cidr_blocks       = var.permitted_cidrs
+  security_group_id = aws_security_group.application_rds.id
+
+  from_port = 5432
+  to_port   = 5432
+}

--- a/terraform/modules/aws/rds/subnets.tf
+++ b/terraform/modules/aws/rds/subnets.tf
@@ -1,0 +1,21 @@
+// Creates a /24 subnet in each avaialbility zone starting at the provided base subnet
+resource "aws_subnet" "rds_subnet" {
+  for_each = toset(data.aws_availability_zones.available.names)
+
+  vpc_id            = var.vpc_id
+  availability_zone = each.value
+  cidr_block        = cidrsubnet(var.vpc_cidr, 8, index(data.aws_availability_zones.available.names, each.value))
+
+  map_public_ip_on_launch = false
+
+  tags = {
+    Name = "${var.environment}-rds-${index(data.aws_availability_zones.available.names, each.value) + 1}"
+  }
+}
+
+resource "aws_route_table_association" "rds_subnet" {
+  for_each = aws_subnet.rds_subnet
+
+  subnet_id      = each.value.id
+  route_table_id = var.route_table_id
+}

--- a/terraform/modules/aws/rds/subnets.tf
+++ b/terraform/modules/aws/rds/subnets.tf
@@ -1,3 +1,5 @@
+data "aws_availability_zones" "available" {}
+
 // Creates a /24 subnet in each avaialbility zone starting at the provided base subnet
 resource "aws_subnet" "rds_subnet" {
   for_each = toset(data.aws_availability_zones.available.names)

--- a/terraform/modules/aws/rds/variables.tf
+++ b/terraform/modules/aws/rds/variables.tf
@@ -1,0 +1,24 @@
+variable "use_rds" {
+  type = bool
+}
+
+variable "environment" {
+  type        = string
+  description = "Environment name (for example: staging)"
+}
+
+variable "vpc_id" {
+  type = string
+}
+
+variable "vpc_cidr" {
+  type = string
+}
+
+variable "route_table_id" {
+  type = string
+}
+
+variable "base_subnet" {
+  type = number
+}

--- a/terraform/modules/aws/rds/variables.tf
+++ b/terraform/modules/aws/rds/variables.tf
@@ -1,7 +1,3 @@
-variable "use_rds" {
-  type = bool
-}
-
 variable "environment" {
   type        = string
   description = "Environment name (for example: staging)"

--- a/terraform/modules/aws/rds/variables.tf
+++ b/terraform/modules/aws/rds/variables.tf
@@ -22,3 +22,8 @@ variable "route_table_id" {
 variable "base_subnet" {
   type = number
 }
+
+variable "permitted_cidrs" {
+  type        = list(string)
+  description = "A list of CIDR blocks permitted by the RDS security group ingress rules"
+}

--- a/terraform/modules/aws/variables.tf
+++ b/terraform/modules/aws/variables.tf
@@ -18,6 +18,11 @@ variable "paas_public_ips" {
   default = ["52.208.24.161", "52.208.1.143", "52.51.250.21"]
 }
 
+variable "paas_ireland_cidr" {
+  type    = string
+  default = "10.0.0.0/16"
+}
+
 variable "vpc_cidr" {
   type        = string
   description = "The default VPC cidr range for this environment. This may differ between environments to support VPC peering without overlapping ranges."

--- a/terraform/modules/aws/variables.tf
+++ b/terraform/modules/aws/variables.tf
@@ -23,3 +23,12 @@ variable "vpc_cidr" {
   description = "The default VPC cidr range for this environment. This may differ between environments to support VPC peering without overlapping ranges."
   default     = "172.16.0.0/16"
 }
+
+variable "subnet_reservations" {
+  type        = map
+  description = "A map of base subnets in the environment. Gaps must be equal or greater than the number of AZs in a region."
+
+  default = {
+    "rds" = 0
+  }
+}

--- a/terraform/modules/aws/vpc.tf
+++ b/terraform/modules/aws/vpc.tf
@@ -1,5 +1,3 @@
-data "aws_availability_zones" "available" {}
-
 resource "aws_vpc" "default" {
   cidr_block = var.vpc_cidr
 


### PR DESCRIPTION
 - Creates a subnet in each AZ for placement of RDS instances
 - CIDR for staging VPC is `172.20.0.0/16`. 
 - RDS subnet range starts at 0, (defined in `subnet_ranges`). This produces the following subnets: `172.20.0.0/24`, `172.20.1.0/24`, `172.20.2.0/24`.
 - Creates a security group with a rule allowing ingress from PaaS Ireland VPC internal (peered) CIDR range
