### PR TITLE
PP-6914: Move Staging AWS infra to eu-west-1 region

### DIFF
--- a/terraform/staging-aws/site.tf
+++ b/terraform/staging-aws/site.tf
@@ -8,7 +8,7 @@ terraform {
 
 provider "aws" {
   version = "~> 3.0"
-  region  = "eu-west-2"
+  region  = "eu-west-1"
 
   allowed_account_ids = ["234617505259"]
 }


### PR DESCRIPTION
We have torn down all Staging infra in the `eu-west-2` region. This change will move infra to `eu-west-1` to align with PaaS Ireland infra location.