### PR TITLE
PP-6913: Provision RDS instances

### DIFF
--- a/terraform/modules/aws/rds.tf
+++ b/terraform/modules/aws/rds.tf
@@ -9,4 +9,5 @@ module "rds" {
   route_table_id  = aws_route_table.default.id
   base_subnet     = var.subnet_reservations.rds
   permitted_cidrs = [var.paas_ireland_cidr]
+  rds_instances   = var.rds_instances
 }

--- a/terraform/modules/aws/rds/main.tf
+++ b/terraform/modules/aws/rds/main.tf
@@ -1,0 +1,12 @@
+locals {
+  databases = []
+}
+
+resource "aws_db_instance" "default" {
+
+  for_each = local.databases
+
+  identifier = "${var.environment}-${each.value.name}-rds"
+
+  db_subnet_group_name = aws_db_subnet_group.rds_subnet_group
+}

--- a/terraform/modules/aws/rds/main.tf
+++ b/terraform/modules/aws/rds/main.tf
@@ -1,12 +1,32 @@
-locals {
-  databases = []
+provider "pass" {
+  version       = "~> 1.2"
+  store_dir     = "../../../pay-low-pass"
+  refresh_store = false
+  alias         = "low-pass"
 }
 
-resource "aws_db_instance" "default" {
+data "pass_password" "db_passwords" {
+  for_each = var.rds_instances
+  path     = "aws/paas/staging/rds/superuser/${replace(each.key, "-", "_")}/payment-password"
+  provider = pass.low-pass
+}
 
-  for_each = local.databases
+resource "aws_db_instance" "postgres" {
+  for_each = var.rds_instances
 
-  identifier = "${var.environment}-${each.value.name}-rds"
+  identifier = "${var.environment}-${each.key}-rds"
 
-  db_subnet_group_name = aws_db_subnet_group.rds_subnet_group
+  allocated_storage   = try(each.value.allocated_storage, var.default_rds_params.allocated_storage)
+  storage_type        = try(each.value.storage_type, var.default_rds_params.storage_type)
+  engine              = try(each.value.engine, var.default_rds_params.engine)
+  engine_version      = try(each.value.engine_version, var.default_rds_params.engine_version)
+  instance_class      = try(each.value.instance_class, var.default_rds_params.instance_class)
+  multi_az            = try(each.value.multi_az, var.default_rds_params.multi_az)
+  skip_final_snapshot = true
+  snapshot_identifier = try(each.value.snapshot_identifier, null)
+  username            = "payments"
+  password            = "data.db_passwords.${each.key}"
+
+  vpc_security_group_ids = [aws_security_group.application_rds.id]
+  db_subnet_group_name   = aws_db_subnet_group.rds_subnet_group.name
 }

--- a/terraform/modules/aws/rds/subnets.tf
+++ b/terraform/modules/aws/rds/subnets.tf
@@ -26,7 +26,7 @@ resource "aws_db_subnet_group" "rds_subnet_group" {
   name        = "${var.environment}-rds"
   description = "${var.environment} RDS subnet group"
 
-  subnet_ids = values(aws_subnet.aws_subnet)[*].id
+  subnet_ids = values(aws_subnet.rds_subnet)[*].id
 }
 
 resource "aws_security_group" "application_rds" {

--- a/terraform/modules/aws/rds/subnets.tf
+++ b/terraform/modules/aws/rds/subnets.tf
@@ -22,6 +22,13 @@ resource "aws_route_table_association" "rds_subnet" {
   route_table_id = var.route_table_id
 }
 
+resource "aws_db_subnet_group" "rds_subnet_group" {
+  name        = "${var.environment}-rds"
+  description = "${var.environment} RDS subnet group"
+
+  subnet_ids = values(aws_subnet.aws_subnet)[*].id
+}
+
 resource "aws_security_group" "application_rds" {
   name        = "${var.environment}-sg-rds"
   description = "${var.environment} RDS database security group"

--- a/terraform/modules/aws/rds/variables.tf
+++ b/terraform/modules/aws/rds/variables.tf
@@ -23,3 +23,17 @@ variable "permitted_cidrs" {
   type        = list(string)
   description = "A list of CIDR blocks permitted by the RDS security group ingress rules"
 }
+
+variable "default_rds_params" {
+  type        = map
+  description = "A map of default settings for all RDS instances provisioned in an environment"
+
+  default = {
+    disk_size      = 20
+    storage_type   = "gp2"
+    engine         = "postgres"
+    engine_version = "11.1"
+    instance_class = "db.t3.small"
+    multi_az       = false
+  }
+}

--- a/terraform/modules/aws/rds/variables.tf
+++ b/terraform/modules/aws/rds/variables.tf
@@ -29,11 +29,16 @@ variable "default_rds_params" {
   description = "A map of default settings for all RDS instances provisioned in an environment"
 
   default = {
-    disk_size      = 20
-    storage_type   = "gp2"
-    engine         = "postgres"
-    engine_version = "11.1"
-    instance_class = "db.t3.small"
-    multi_az       = false
+    allocated_storage = 20
+    storage_type      = "gp2"
+    engine            = "postgres"
+    engine_version    = "11.1"
+    instance_class    = "db.t3.small"
+    multi_az          = false
   }
+}
+
+variable "rds_instances" {
+  type    = map
+  default = {}
 }

--- a/terraform/modules/aws/variables.tf
+++ b/terraform/modules/aws/variables.tf
@@ -13,6 +13,12 @@ variable "paas_domain" {
   description = "PaaS domain for Cloudfront origin"
 }
 
+variable "paas_vpc_peering_name" {
+  type        = string
+  description = "The name of the vpc peering connection with PaaS"
+  default     = "pcx-0d726a5057505ab0b"
+}
+
 variable "paas_public_ips" {
   type    = list
   default = ["52.208.24.161", "52.208.1.143", "52.51.250.21"]
@@ -36,4 +42,9 @@ variable "subnet_reservations" {
   default = {
     "rds" = 0
   }
+}
+
+variable "rds_instances" {
+  type    = map
+  default = {}
 }

--- a/terraform/modules/aws/vpc.tf
+++ b/terraform/modules/aws/vpc.tf
@@ -15,6 +15,11 @@ resource "aws_route_table" "default" {
   tags = {
     Name = "${var.environment}-route"
   }
+
+  route {
+    cidr_block                = var.paas_ireland_cidr
+    vpc_peering_connection_id = var.paas_vpc_peering_name
+  }
 }
 
 resource "aws_default_security_group" "default" {

--- a/terraform/staging-aws/site.tf
+++ b/terraform/staging-aws/site.tf
@@ -34,6 +34,11 @@ provider "pass" {
   alias         = "low-pass"
 }
 
+variable "rds_instances" {
+  type    = map
+  default = {}
+}
+
 module "staging" {
   source = "../modules/aws"
 
@@ -44,11 +49,11 @@ module "staging" {
     pass.low-pass = pass.low-pass
   }
 
-  environment = "staging"
-  domain_name = "gdspay.uk"
-  paas_domain = "cloudapps.digital"
-  vpc_cidr    = "172.16.0.0/16"
-
+  environment   = "staging"
+  domain_name   = "gdspay.uk"
+  paas_domain   = "cloudapps.digital"
+  vpc_cidr      = "172.16.0.0/16"
+  rds_instances = var.rds_instances
   subnet_reservations = {
     "rds" = 36
   }

--- a/terraform/staging-aws/terraform.tfvars
+++ b/terraform/staging-aws/terraform.tfvars
@@ -1,0 +1,6 @@
+rds_instances = {
+  card-connector = {
+    allocated_storage = 110
+    snapshot_identifier = "arn:aws:rds:eu-west-1:234617505259:snapshot:card-connector-copied-snap-shot"
+  }
+}


### PR DESCRIPTION
Provisions all RDS instances within an RDS subnet group in a given environment.

- Accepts a map of database instances with optional configuration
- Default configuration is applied where values are omitted
- Configures a VPC peering connection to the RDS subnet group from GOV.UK PaaS
- Adds peering connection to VPC routing table