### PR TITLE
PP-6914: Update VPC cidr & RDS base subnet

### DIFF
--- a/terraform/modules/aws/rds/subnets.tf
+++ b/terraform/modules/aws/rds/subnets.tf
@@ -6,7 +6,7 @@ resource "aws_subnet" "rds_subnet" {
 
   vpc_id            = var.vpc_id
   availability_zone = each.value
-  cidr_block        = cidrsubnet(var.vpc_cidr, 8, index(data.aws_availability_zones.available.names, each.value))
+  cidr_block        = cidrsubnet(var.vpc_cidr, 8, index(data.aws_availability_zones.available.names, each.value) + var.base_subnet)
 
   map_public_ip_on_launch = false
 

--- a/terraform/staging-aws/site.tf
+++ b/terraform/staging-aws/site.tf
@@ -47,5 +47,9 @@ module "staging" {
   environment = "staging"
   domain_name = "gdspay.uk"
   paas_domain = "cloudapps.digital"
-  vpc_cidr    = "172.20.0.0/16"
+  vpc_cidr    = "172.16.0.0/16"
+
+  subnet_reservations = {
+    "rds" = 36
+  }
 }


### PR DESCRIPTION
This change updates the Staging AWS account VPC CIDR to 172.16.0.0/16 and updates the base RDS subnet group range to a CIDR within a range compatible with PaaS for VPC peering.