### PR TITLE
PP-6913 Update the aws region used for paas module

### DIFF
--- a/terraform/staging-paas/site.tf
+++ b/terraform/staging-paas/site.tf
@@ -19,7 +19,7 @@ provider "cloudfoundry" {
 
 provider "aws" {
   version = "~> 3.0"
-  region  = "eu-west-2"
+  region  = "eu-west-1"
 }
 
 data "aws_region" "current" {}


### PR DESCRIPTION
This is used by the sqs ups to set the correct sqs url.

## WHAT ##
Already applied to paas staging and ledger/card-connector now start up.