### PR TITLE
Pp 6913 add remaining dbs

### DIFF
--- a/terraform/modules/aws/cloudfront_logging/transformation-lambda.tf
+++ b/terraform/modules/aws/cloudfront_logging/transformation-lambda.tf
@@ -3,9 +3,9 @@ locals {
 }
 
 data "archive_file" "zip_transformation_lambda" {
-    type        = "zip"
-    source_file = "${path.module}/../../../../lambda/${local.transformation_lambda_function_name}/index.js"
-    output_path = "${path.module}/../../../../lambda/${local.transformation_lambda_function_name}/index.zip"
+  type        = "zip"
+  source_file = "${path.module}/../../../../lambda/${local.transformation_lambda_function_name}/index.js"
+  output_path = "${path.module}/../../../../lambda/${local.transformation_lambda_function_name}/index.zip"
 }
 
 resource "aws_lambda_function" "kinesis_data_transformation_lambda" {
@@ -19,7 +19,7 @@ resource "aws_lambda_function" "kinesis_data_transformation_lambda" {
   timeout          = 60
 
   depends_on = [
-    aws_iam_role_policy_attachment.transfomation_lambda_logs, 
+    aws_iam_role_policy_attachment.transfomation_lambda_logs,
     aws_cloudwatch_log_group.cloudfront_log_kinesis_data_transformation_log_group
   ]
 }
@@ -31,7 +31,7 @@ resource "aws_cloudwatch_log_group" "cloudfront_log_kinesis_data_transformation_
 }
 
 resource "aws_iam_role" "iam_kinesis_data_transformation_lambda" {
-  name = "${local.transformation_lambda_function_name}-role"
+  name               = "${local.transformation_lambda_function_name}-role"
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -50,6 +50,6 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "transfomation_lambda_logs" {
-  role       = "${aws_iam_role.iam_kinesis_data_transformation_lambda.name}"
+  role       = aws_iam_role.iam_kinesis_data_transformation_lambda.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
 }

--- a/terraform/modules/aws/hosted-graphite.tf
+++ b/terraform/modules/aws/hosted-graphite.tf
@@ -39,5 +39,5 @@ EOF
 resource "aws_iam_policy_attachment" "hosted_graphite" {
   name       = "HostedGraphite"
   users      = ["${aws_iam_user.hosted_graphite.name}"]
-  policy_arn = "${aws_iam_policy.hosted_graphite_policy.arn}"
+  policy_arn = aws_iam_policy.hosted_graphite_policy.arn
 }

--- a/terraform/modules/aws/notifications.tf
+++ b/terraform/modules/aws/notifications.tf
@@ -47,7 +47,7 @@ resource "aws_cloudfront_distribution" "notifications" {
 
   origin {
     origin_id   = "paas"
-    domain_name = "${var.paas_domain}"
+    domain_name = var.paas_domain
 
     custom_origin_config {
       http_port              = 80
@@ -73,7 +73,7 @@ resource "aws_cloudfront_distribution" "notifications" {
 }
 
 module notifications_waf_acl {
-  source          = "./waf_v2_acl" 
+  source          = "./waf_v2_acl"
   name            = "notifications-${var.environment}"
   description     = "Notifications ACL ${var.environment}"
   log_destination = module.waf_logging.kinesis_stream_id

--- a/terraform/modules/aws/products-ui.tf
+++ b/terraform/modules/aws/products-ui.tf
@@ -47,7 +47,7 @@ resource "aws_cloudfront_distribution" "products_ui" {
 
   origin {
     origin_id   = "paas"
-    domain_name = "${var.paas_domain}"
+    domain_name = var.paas_domain
 
     custom_origin_config {
       http_port              = 80
@@ -73,7 +73,7 @@ resource "aws_cloudfront_distribution" "products_ui" {
 }
 
 module products_ui_waf_acl {
-  source          = "./waf_v2_acl" 
+  source          = "./waf_v2_acl"
   name            = "products-ui-${var.environment}"
   description     = "Products UI ACL ${var.environment}"
   log_destination = module.waf_logging.kinesis_stream_id

--- a/terraform/modules/aws/publicapi.tf
+++ b/terraform/modules/aws/publicapi.tf
@@ -47,7 +47,7 @@ resource "aws_cloudfront_distribution" "publicapi" {
 
   origin {
     origin_id   = "paas"
-    domain_name = "${var.paas_domain}"
+    domain_name = var.paas_domain
 
     custom_origin_config {
       http_port              = 80
@@ -73,7 +73,7 @@ resource "aws_cloudfront_distribution" "publicapi" {
 }
 
 module publicapi_waf_acl {
-  source      = "./waf_v2_acl" 
+  source      = "./waf_v2_acl"
   name        = "publicapi-${var.environment}"
   description = "Publicapi ACL ${var.environment}"
   acl         = <<EOF

--- a/terraform/modules/aws/rds/main.tf
+++ b/terraform/modules/aws/rds/main.tf
@@ -18,6 +18,7 @@ resource "aws_db_instance" "postgres" {
 
   allocated_storage   = try(each.value.allocated_storage, var.default_rds_params.allocated_storage)
   storage_type        = try(each.value.storage_type, var.default_rds_params.storage_type)
+  storage_encrypted   = true
   engine              = try(each.value.engine, var.default_rds_params.engine)
   engine_version      = try(each.value.engine_version, var.default_rds_params.engine_version)
   instance_class      = try(each.value.instance_class, var.default_rds_params.instance_class)
@@ -29,4 +30,8 @@ resource "aws_db_instance" "postgres" {
 
   vpc_security_group_ids = [aws_security_group.application_rds.id]
   db_subnet_group_name   = aws_db_subnet_group.rds_subnet_group.name
+
+  lifecycle {
+    ignore_changes = ["snapshot_identifier"]
+  }
 }

--- a/terraform/modules/aws/rds/main.tf
+++ b/terraform/modules/aws/rds/main.tf
@@ -32,6 +32,6 @@ resource "aws_db_instance" "postgres" {
   db_subnet_group_name   = aws_db_subnet_group.rds_subnet_group.name
 
   lifecycle {
-    ignore_changes = ["snapshot_identifier"]
+    ignore_changes = [snapshot_identifier]
   }
 }

--- a/terraform/modules/aws/selfservice.tf
+++ b/terraform/modules/aws/selfservice.tf
@@ -47,7 +47,7 @@ resource "aws_cloudfront_distribution" "selfservice" {
 
   origin {
     origin_id   = "paas"
-    domain_name = "${var.paas_domain}"
+    domain_name = var.paas_domain
 
     custom_origin_config {
       http_port              = 80
@@ -73,7 +73,7 @@ resource "aws_cloudfront_distribution" "selfservice" {
 }
 
 module selfservice_waf_acl {
-  source          = "./waf_v2_acl" 
+  source          = "./waf_v2_acl"
   name            = "selfservice-${var.environment}"
   description     = "Selfservice ACL ${var.environment}"
   log_destination = module.waf_logging.kinesis_stream_id

--- a/terraform/modules/aws/variables.tf
+++ b/terraform/modules/aws/variables.tf
@@ -16,7 +16,7 @@ variable "paas_domain" {
 variable "paas_vpc_peering_name" {
   type        = string
   description = "The name of the vpc peering connection with PaaS"
-  default     = "pcx-0d726a5057505ab0b"
+  default     = ""
 }
 
 variable "paas_public_ips" {

--- a/terraform/modules/aws/waf_logging/lambda.tf
+++ b/terraform/modules/aws/waf_logging/lambda.tf
@@ -3,9 +3,9 @@ locals {
 }
 
 data "archive_file" "zip_lambda" {
-    type        = "zip"
-    source_file = "${path.module}/../../../../lambda/waf-to-splunk-kinesis-data-transformation/index.js"
-    output_path = "${path.module}/../../../../lambda/waf-to-splunk-kinesis-data-transformation/index.zip"
+  type        = "zip"
+  source_file = "${path.module}/../../../../lambda/waf-to-splunk-kinesis-data-transformation/index.js"
+  output_path = "${path.module}/../../../../lambda/waf-to-splunk-kinesis-data-transformation/index.zip"
 }
 
 resource "aws_lambda_function" "kinesis_data_transformation_lambda" {
@@ -20,7 +20,7 @@ resource "aws_lambda_function" "kinesis_data_transformation_lambda" {
   timeout          = 60
 
   depends_on = [
-    aws_iam_role_policy_attachment.lambda_logs, 
+    aws_iam_role_policy_attachment.lambda_logs,
     aws_cloudwatch_log_group.waf_kinesis_data_transformation_log_group
   ]
 }
@@ -32,7 +32,7 @@ resource "aws_cloudwatch_log_group" "waf_kinesis_data_transformation_log_group" 
 }
 
 resource "aws_iam_role" "iam_kinesis_data_transformation_lambda" {
-  name = "${local.lambda_function_name}-role"
+  name               = "${local.lambda_function_name}-role"
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -51,6 +51,6 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "lambda_logs" {
-  role       = "${aws_iam_role.iam_kinesis_data_transformation_lambda.name}"
+  role       = aws_iam_role.iam_kinesis_data_transformation_lambda.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
 }

--- a/terraform/staging-aws/site.tf
+++ b/terraform/staging-aws/site.tf
@@ -49,11 +49,12 @@ module "staging" {
     pass.low-pass = pass.low-pass
   }
 
-  environment   = "staging"
-  domain_name   = "gdspay.uk"
-  paas_domain   = "cloudapps.digital"
-  vpc_cidr      = "172.16.0.0/16"
-  rds_instances = var.rds_instances
+  environment           = "staging"
+  domain_name           = "gdspay.uk"
+  paas_domain           = "cloudapps.digital"
+  vpc_cidr              = "172.16.0.0/16"
+  paas_vpc_peering_name = "pcx-0d726a5057505ab0b"
+  rds_instances         = var.rds_instances
   subnet_reservations = {
     "rds" = 36
   }

--- a/terraform/staging-aws/terraform.tfvars
+++ b/terraform/staging-aws/terraform.tfvars
@@ -1,23 +1,18 @@
 rds_instances = {
   adminusers = {
     allocated_storage = 30
-    snapshot_identifier = "arn:aws:rds:eu-west-1:234617505259:snapshot:adminusers-copy"
   }
   card-connector = {
     allocated_storage = 110
-    snapshot_identifier = "arn:aws:rds:eu-west-1:234617505259:snapshot:card-connector-copied-snap-shot"
   }
   ledger = {
     allocated_storage = 125
-    snapshot_identifier = "arn:aws:rds:eu-west-1:234617505259:snapshot:ledger-copy"
     engine_version = "11.4"
   }
   publicauth = {
     allocated_storage = 50
-    snapshot_identifier = "arn:aws:rds:eu-west-1:234617505259:snapshot:publicauth-copy"
   }
   products = {
     allocated_storage = 10
-    snapshot_identifier = "arn:aws:rds:eu-west-1:234617505259:snapshot:products-copy"
   }
 }

--- a/terraform/staging-aws/terraform.tfvars
+++ b/terraform/staging-aws/terraform.tfvars
@@ -1,6 +1,23 @@
 rds_instances = {
+  adminusers = {
+    allocated_storage = 30
+    snapshot_identifier = "arn:aws:rds:eu-west-1:234617505259:snapshot:adminusers-copy"
+  }
   card-connector = {
     allocated_storage = 110
     snapshot_identifier = "arn:aws:rds:eu-west-1:234617505259:snapshot:card-connector-copied-snap-shot"
+  }
+  ledger = {
+    allocated_storage = 125
+    snapshot_identifier = "arn:aws:rds:eu-west-1:234617505259:snapshot:ledger-copy"
+    engine_version = "11.4"
+  }
+  publicauth = {
+    allocated_storage = 50
+    snapshot_identifier = "arn:aws:rds:eu-west-1:234617505259:snapshot:publicauth-copy"
+  }
+  products = {
+    allocated_storage = 10
+    snapshot_identifier = "arn:aws:rds:eu-west-1:234617505259:snapshot:products-copy"
   }
 }


### PR DESCRIPTION
- Add remaining dbs in similar fashion to `card-connector`.
- Fix up deprecation warnings.
- Ignore changes to snapshot identifiers and remove them now that we've created the databases since we don't want to reset the dbs to these snapshots each time we TF the environment.
- Pass the paas vpc peering connection name in from `staging-aws/site.tf` since it'll be different for each environment.