### PR TITLE
BAU: Enable RDS performance insights with default settings for all DBs

### DIFF
--- a/terraform/modules/aws/rds/main.tf
+++ b/terraform/modules/aws/rds/main.tf
@@ -33,7 +33,7 @@ resource "aws_db_instance" "postgres" {
   password            = "data.db_passwords.${each.key}"
 
   performance_insights_enabled    = true
-  performance_insights_kms_key_id = data.aws_kms_alias.rds.target_key_id
+  performance_insights_kms_key_id = data.aws_kms_alias.rds.target_key_arn
 
   vpc_security_group_ids = [aws_security_group.application_rds.id]
   db_subnet_group_name   = aws_db_subnet_group.rds_subnet_group.name

--- a/terraform/modules/aws/rds/main.tf
+++ b/terraform/modules/aws/rds/main.tf
@@ -11,6 +11,10 @@ data "pass_password" "db_passwords" {
   provider = pass.low-pass
 }
 
+data "aws_kms_alias" "rds" {
+  name = "alias/aws/rds"
+}
+
 resource "aws_db_instance" "postgres" {
   for_each = var.rds_instances
 
@@ -27,6 +31,9 @@ resource "aws_db_instance" "postgres" {
   snapshot_identifier = try(each.value.snapshot_identifier, null)
   username            = "payments"
   password            = "data.db_passwords.${each.key}"
+
+  performance_insights_enabled    = true
+  performance_insights_kms_key_id = data.aws_kms_alias.rds.target_key_id
 
   vpc_security_group_ids = [aws_security_group.application_rds.id]
   db_subnet_group_name   = aws_db_subnet_group.rds_subnet_group.name


### PR DESCRIPTION
Enables performance insights to aid debugging of DB performance issues.

- Provides 7-day retention of performance data.
- Performance data is encrypted with default RDS KMS key

More info: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PerfInsights.Overview.html