### PR TITLE
PP-7020 Add db credentials for card-connector

### DIFF
--- a/terraform/modules/paas/adminusers.tf
+++ b/terraform/modules/paas/adminusers.tf
@@ -35,5 +35,5 @@ module "adminusers_credentials" {
 resource "cloudfoundry_user_provided_service" "adminusers_secret_service" {
   name        = "adminusers-secret-service"
   space       = data.cloudfoundry_space.space.id
-  credentials = merge(module.adminusers_credentials.secrets, lookup(local.adminusers_credentials, "static_values"))
+  credentials = merge(module.adminusers_credentials.secrets, lookup(local.adminusers_credentials, "static_values"), { db_host = var.rds_host_names["adminusers"].address })
 }

--- a/terraform/modules/paas/card-connector.tf
+++ b/terraform/modules/paas/card-connector.tf
@@ -35,5 +35,5 @@ module "card_connector_credentials" {
 resource "cloudfoundry_user_provided_service" "card_connector_secret_service" {
   name        = "card-connector-secret-service"
   space       = data.cloudfoundry_space.cde_space.id
-  credentials = merge(module.card_connector_credentials.secrets, lookup(local.card_connector_credentials, "static_values"))
+  credentials = merge(module.card_connector_credentials.secrets, lookup(local.card_connector_credentials, "static_values"), { db_host = lookup(var.rds_host_names, "card_connector").address })
 }

--- a/terraform/modules/paas/card-connector.tf
+++ b/terraform/modules/paas/card-connector.tf
@@ -35,5 +35,5 @@ module "card_connector_credentials" {
 resource "cloudfoundry_user_provided_service" "card_connector_secret_service" {
   name        = "card-connector-secret-service"
   space       = data.cloudfoundry_space.cde_space.id
-  credentials = merge(module.card_connector_credentials.secrets, lookup(local.card_connector_credentials, "static_values"), { db_host = lookup(var.rds_host_names, "card_connector").address })
+  credentials = merge(module.card_connector_credentials.secrets, lookup(local.card_connector_credentials, "static_values"), { db_host = var.rds_host_names["card_connector"].address })
 }

--- a/terraform/modules/paas/ledger.tf
+++ b/terraform/modules/paas/ledger.tf
@@ -35,5 +35,5 @@ module "ledger_credentials" {
 resource "cloudfoundry_user_provided_service" "ledger_secret_service" {
   name        = "ledger-secret-service"
   space       = data.cloudfoundry_space.space.id
-  credentials = merge(module.ledger_credentials.secrets, lookup(local.ledger_credentials, "static_values"))
+  credentials = merge(module.ledger_credentials.secrets, lookup(local.ledger_credentials, "static_values"), { db_host = var.rds_host_names["ledger"].address })
 }

--- a/terraform/modules/paas/products.tf
+++ b/terraform/modules/paas/products.tf
@@ -35,5 +35,5 @@ module "products_credentials" {
 resource "cloudfoundry_user_provided_service" "products_secret_service" {
   name        = "products-secret-service"
   space       = data.cloudfoundry_space.space.id
-  credentials = merge(module.products_credentials.secrets, lookup(local.products_credentials, "static_values"))
+  credentials = merge(module.products_credentials.secrets, lookup(local.products_credentials, "static_values"), { db_host = var.rds_host_names["products"].address })
 }

--- a/terraform/modules/paas/publicauth.tf
+++ b/terraform/modules/paas/publicauth.tf
@@ -35,5 +35,5 @@ module "publicauth_credentials" {
 resource "cloudfoundry_user_provided_service" "publicauth_secret_service" {
   name        = "publicauth-secret-service"
   space       = data.cloudfoundry_space.space.id
-  credentials = merge(module.publicauth_credentials.secrets, lookup(local.publicauth_credentials, "static_values"))
+  credentials = merge(module.publicauth_credentials.secrets, lookup(local.publicauth_credentials, "static_values"), { db_host = var.rds_host_names["publicauth"].address })
 }

--- a/terraform/modules/paas/variables.tf
+++ b/terraform/modules/paas/variables.tf
@@ -44,3 +44,8 @@ variable "aws_account_id" {
   type        = string
   description = "AWS account id to use in configuration passed to user provided services etc."
 }
+
+variable "rds_host_names" {
+  type        = map
+  description = "Map of rds host names for the apps"
+}

--- a/terraform/staging-paas/site.tf
+++ b/terraform/staging-paas/site.tf
@@ -26,6 +26,10 @@ data "aws_region" "current" {}
 
 data "aws_caller_identity" "current" {}
 
+data "aws_db_instance" "card_connector_rds" {
+  db_instance_identifier = "staging-card-connector-rds"
+}
+
 module "paas" {
   source = "../modules/paas"
 
@@ -38,6 +42,7 @@ module "paas" {
   credentials              = var.credentials
   aws_region               = data.aws_region.current.name
   aws_account_id           = data.aws_caller_identity.current.account_id
+  rds_host_names           = { card_connector = data.aws_db_instance.card_connector_rds }
 }
 
 module "paas_postgres" {

--- a/terraform/staging-paas/site.tf
+++ b/terraform/staging-paas/site.tf
@@ -26,8 +26,9 @@ data "aws_region" "current" {}
 
 data "aws_caller_identity" "current" {}
 
-data "aws_db_instance" "card_connector_rds" {
-  db_instance_identifier = "staging-card-connector-rds"
+data "aws_db_instance" "db_instances" {
+  for_each               = toset(["ledger", "products", "card_connector", "adminusers", "publicauth"])
+  db_instance_identifier = "staging-${replace(each.key, "_", "-")}-rds"
 }
 
 module "paas" {
@@ -42,7 +43,7 @@ module "paas" {
   credentials              = var.credentials
   aws_region               = data.aws_region.current.name
   aws_account_id           = data.aws_caller_identity.current.account_id
-  rds_host_names           = { card_connector = data.aws_db_instance.card_connector_rds }
+  rds_host_names           = data.aws_db_instance.db_instances
 }
 
 module "paas_postgres" {

--- a/terraform/staging-paas/terraform.tfvars
+++ b/terraform/staging-paas/terraform.tfvars
@@ -31,6 +31,7 @@ credentials = {
       stripe_webhook_live_sign_secret          = "stripe/staging/test/webhook-secret"
       notify_payment_receipt_email_template_id = "notify/templates/paas/staging/connector.notify_payment_receipt_email_template_id"
       notify_refund_email_template_id          = "notify/templates/paas/staging/connector.notify_refund_issued_template_id"
+      db_password                              = "aws/paas/staging/rds/application_users/card_connector/connector1"
     }
     static_values = {
       secure_worldpay_notification_domain  = "london.cloudapps.digital"
@@ -44,6 +45,8 @@ credentials = {
       sqs_enabled                          = "true"
       stripe_transaction_fee_percentage    = "0.1"
       card_connector_analytics_tracking_id = "testing-123"
+      db_user                              = "connector1"
+      db_name                              = "connector"
     }
   }
   cardid = {

--- a/terraform/staging-paas/terraform.tfvars
+++ b/terraform/staging-paas/terraform.tfvars
@@ -58,12 +58,15 @@ credentials = {
   }
   publicauth = {
     pay_low_pass_secrets = {
-      sentry_dsn = "sentry/publicauth_dsn"
+      sentry_dsn  = "sentry/publicauth_dsn"
+      db_password = "aws/paas/staging/rds/application_users/publicauth/publicauth1"
     }
     static_values = {
       // @todo move these to secret store (placeholder for now)
       token_db_bcrypt_salt  = "$2a$12$ZqrGf7v9uNXR6htsfz4k2u"
       token_api_hmac_secret = "something"
+      db_user               = "publicauth1"
+      db_name               = "publicauth"
     }
   }
   card_frontend = {
@@ -100,17 +103,23 @@ credentials = {
       aws_access_key = "aws/paas/staging/iam/ledger/access_key"
       aws_secret_key = "aws/paas/staging/iam/ledger/secret_key"
       sentry_dsn     = "sentry/ledger_dsn"
+      db_password    = "aws/paas/staging/rds/application_users/ledger/ledger"
     }
     static_values = {
+      db_user = "ledger"
+      db_name = "ledger"
     }
   }
   products = {
     pay_low_pass_secrets = {
-      sentry_dsn = "sentry/products_dsn"
+      sentry_dsn  = "sentry/products_dsn"
+      db_password = "aws/paas/staging/rds/application_users/products/products"
     }
     static_values = {
       // @todo add this placeholder to secrets
       products_api_token = "something"
+      db_user            = "products"
+      db_name            = "products"
     }
   }
   products_ui = {
@@ -139,8 +148,11 @@ credentials = {
       notify_live_account_created_email_template_id                               = "notify/templates/paas/staging/adminusers.notify_live_account_created_email_template_id"
       notify_self_initiated_create_user_and_service_otp_sms_template_id           = "notify/templates/paas/staging/adminusers.notify_self_initiated_create_user_and_service_otp_sms_template_id"
       notify_sign_in_otp_template_id                                              = "notify/templates/paas/staging/adminusers.notify_sign_in_otp_template_id"
+      db_password                                                                 = "aws/paas/staging/rds/application_users/adminusers/adminusers1"
     }
     static_values = {
+      db_user = "adminusers1"
+      db_name = "adminusers"
     }
   }
   directdebit_frontend = {


### PR DESCRIPTION
Add the peered in rds credentials for connector db to the
card-connector-secret-service. The `db_host` comes from a data
`aws_db_instance`. This can be extended using a `for_each` to get the
db_instances for the other apps.