### PR TITLE
PP-7020: Add db SSL connection option to static app configuration

### DIFF
--- a/terraform/staging-paas/terraform.tfvars
+++ b/terraform/staging-paas/terraform.tfvars
@@ -47,6 +47,7 @@ credentials = {
       card_connector_analytics_tracking_id = "testing-123"
       db_user                              = "connector1"
       db_name                              = "connector"
+      db_ssl_option                        = "true"
     }
   }
   cardid = {
@@ -67,6 +68,7 @@ credentials = {
       token_api_hmac_secret = "something"
       db_user               = "publicauth1"
       db_name               = "publicauth"
+      db_ssl_option         = "true"
     }
   }
   card_frontend = {
@@ -106,8 +108,9 @@ credentials = {
       db_password    = "aws/paas/staging/rds/application_users/ledger/ledger"
     }
     static_values = {
-      db_user = "ledger"
-      db_name = "ledger"
+      db_user       = "ledger"
+      db_name       = "ledger"
+      db_ssl_option = "true"
     }
   }
   products = {
@@ -120,6 +123,7 @@ credentials = {
       products_api_token = "something"
       db_user            = "products"
       db_name            = "products"
+      db_ssl_option      = "true"
     }
   }
   products_ui = {
@@ -151,8 +155,9 @@ credentials = {
       db_password                                                                 = "aws/paas/staging/rds/application_users/adminusers/adminusers1"
     }
     static_values = {
-      db_user = "adminusers1"
-      db_name = "adminusers"
+      db_user       = "adminusers1"
+      db_name       = "adminusers"
+      db_ssl_option = "true"
     }
   }
   directdebit_frontend = {


### PR DESCRIPTION
This option is used by apps to ensure DB connections are made over TLS.

A corresponding change should be made to the env-map.yml file in each app's repository to ensure this option is mapped to the `DB_SSL_OPTION` environment variable from the secret service at run time.