### PR TITLE
PP-6913: Remove PaaS provided RDS services

### DIFF
--- a/terraform/staging-paas/site.tf
+++ b/terraform/staging-paas/site.tf
@@ -45,10 +45,3 @@ module "paas" {
   aws_account_id           = data.aws_caller_identity.current.account_id
   rds_host_names           = data.aws_db_instance.db_instances
 }
-
-module "paas_postgres" {
-  source = "../modules/paas-postgres"
-
-  org   = "govuk-pay"
-  space = "staging"
-}


### PR DESCRIPTION
Now that RDS instances used by PaaS apps are accessed via a peered VPC connection, the PaaS RDS service broker databases are no longer required and can be removed from the staging infrastructure.