### PR TITLE
PP-7025 Use separate hosted zones for sub domain delegation

### DIFF
--- a/terraform/modules/aws/card-frontend.tf
+++ b/terraform/modules/aws/card-frontend.tf
@@ -1,6 +1,6 @@
 resource "aws_route53_record" "card_frontend" {
-  zone_id = data.aws_route53_zone.root.zone_id
-  name    = "card-frontend.${local.subdomain}"
+  zone_id = aws_route53_zone.hosted_zone.zone_id
+  name    = "card-frontend.${var.domain_name}"
   type    = "A"
 
   alias {
@@ -25,7 +25,7 @@ resource "aws_cloudfront_distribution" "card_frontend" {
     bucket          = aws_s3_bucket.cloudfront_logs.bucket_domain_name
   }
 
-  aliases = ["card-frontend.${var.environment}.${var.domain_name}"]
+  aliases = ["card-frontend.${var.domain_name}"]
 
   default_cache_behavior {
     target_origin_id       = "paas"

--- a/terraform/modules/aws/notifications.tf
+++ b/terraform/modules/aws/notifications.tf
@@ -1,6 +1,6 @@
 resource "aws_route53_record" "notifications" {
-  zone_id = data.aws_route53_zone.root.zone_id
-  name    = "notifications.${local.subdomain}"
+  zone_id = aws_route53_zone.hosted_zone.zone_id
+  name    = "notifications.${var.domain_name}"
   type    = "A"
 
   alias {
@@ -25,7 +25,7 @@ resource "aws_cloudfront_distribution" "notifications" {
     bucket          = aws_s3_bucket.cloudfront_logs.bucket_domain_name
   }
 
-  aliases = ["notifications.${var.environment}.${var.domain_name}"]
+  aliases = ["notifications.${var.domain_name}"]
 
   default_cache_behavior {
     target_origin_id       = "paas"

--- a/terraform/modules/aws/products-ui.tf
+++ b/terraform/modules/aws/products-ui.tf
@@ -1,6 +1,6 @@
 resource "aws_route53_record" "products_ui" {
-  zone_id = data.aws_route53_zone.root.zone_id
-  name    = "products.${local.subdomain}"
+  zone_id = aws_route53_zone.hosted_zone.zone_id
+  name    = "products.${var.domain_name}"
   type    = "A"
 
   alias {
@@ -25,7 +25,7 @@ resource "aws_cloudfront_distribution" "products_ui" {
     bucket          = aws_s3_bucket.cloudfront_logs.bucket_domain_name
   }
 
-  aliases = ["products.${var.environment}.gdspay.uk"]
+  aliases = ["products.${var.domain_name}"]
 
   default_cache_behavior {
     target_origin_id       = "paas"

--- a/terraform/modules/aws/publicapi.tf
+++ b/terraform/modules/aws/publicapi.tf
@@ -1,6 +1,6 @@
 resource "aws_route53_record" "publicapi" {
-  zone_id = data.aws_route53_zone.root.zone_id
-  name    = "publicapi.${local.subdomain}"
+  zone_id = aws_route53_zone.hosted_zone.zone_id
+  name    = "publicapi.${var.domain_name}"
   type    = "A"
 
   alias {
@@ -25,7 +25,7 @@ resource "aws_cloudfront_distribution" "publicapi" {
     bucket          = aws_s3_bucket.cloudfront_logs.bucket_domain_name
   }
 
-  aliases = ["publicapi.${var.environment}.${var.domain_name}"]
+  aliases = ["publicapi.${var.domain_name}"]
 
   default_cache_behavior {
     target_origin_id       = "paas"

--- a/terraform/modules/aws/route53.tf
+++ b/terraform/modules/aws/route53.tf
@@ -1,16 +1,16 @@
-locals {
-  subdomain = "${var.environment}.${var.domain_name}"
-}
-
-data "aws_route53_zone" "root" {
+resource "aws_route53_zone" "hosted_zone" {
   name = var.domain_name
+
+  tags = {
+    Environment = var.environment
+  }
 }
 
 resource "aws_acm_certificate" "cert" {
   provider = aws.us
 
-  domain_name               = local.subdomain
-  subject_alternative_names = ["*.${local.subdomain}"]
+  domain_name               = var.domain_name
+  subject_alternative_names = ["*.${var.domain_name}"]
   validation_method         = "DNS"
 
   lifecycle {
@@ -24,7 +24,7 @@ resource "aws_route53_record" "cert_validation" {
       name    = dvo.resource_record_name
       record  = dvo.resource_record_value
       type    = dvo.resource_record_type
-      zone_id = data.aws_route53_zone.root.id
+      zone_id = aws_route53_zone.hosted_zone.id
     }
   }
 

--- a/terraform/modules/aws/selfservice.tf
+++ b/terraform/modules/aws/selfservice.tf
@@ -1,6 +1,6 @@
 resource "aws_route53_record" "selfservice" {
-  zone_id = data.aws_route53_zone.root.zone_id
-  name    = "selfservice.${local.subdomain}"
+  zone_id = aws_route53_zone.hosted_zone.zone_id
+  name    = "selfservice.${var.domain_name}"
   type    = "A"
 
   alias {
@@ -25,7 +25,7 @@ resource "aws_cloudfront_distribution" "selfservice" {
     bucket          = aws_s3_bucket.cloudfront_logs.bucket_domain_name
   }
 
-  aliases = ["selfservice.${var.environment}.${var.domain_name}"]
+  aliases = ["selfservice.${var.domain_name}"]
 
   default_cache_behavior {
     target_origin_id       = "paas"

--- a/terraform/staging-aws/site.tf
+++ b/terraform/staging-aws/site.tf
@@ -50,7 +50,7 @@ module "staging" {
   }
 
   environment           = "staging"
-  domain_name           = "gdspay.uk"
+  domain_name           = "staging.gdspay.uk"
   paas_domain           = "cloudapps.digital"
   vpc_cidr              = "172.16.0.0/16"
   paas_vpc_peering_name = "pcx-0d726a5057505ab0b"


### PR DESCRIPTION
Currently the staging account has the domain registration for
`gdspay.uk`. To make the terraform consistent for any environment
(test, staging etc) create a hosted zone in which the A records for that
environments' apps are created in. Delegate the subdomain to the new  hosted
zone from the hosted zone in staging which owns the `gdspay.uk`
registration; this is to be done manually for now by adding the
necessary name server record pointing to the name servers of the new
hosted zone.

Remove subdomain interpolation in favour of using `var.domain_name`
passed in from the environment module, e.g. `staging.gdspay.uk`..

Co-authored-by: dan worth <dan.worth@digital.cabinet-office.gov.uk>

## WHAT ##
We've applied this to staging and it all seems to work, smoke tests green and dns resolves as expected.
