### PR TITLE
PP-7025 Add rds instances for test environment

### DIFF
--- a/terraform/test-aws/terraform.tfvars
+++ b/terraform/test-aws/terraform.tfvars
@@ -1,2 +1,19 @@
 rds_instances = {
+  adminusers = {
+    allocated_storage = 10
+  }
+  card-connector = {
+    allocated_storage = 20
+  }
+  ledger = {
+    allocated_storage = 55
+    engine_version    = "11.4"
+  }
+  publicauth = {
+    allocated_storage = 10
+  }
+  products = {
+    allocated_storage = 10
+  }
 }
+


### PR DESCRIPTION
Add configuration for rds postgres instances in the test environment.
The sizes accommodate the snapshots taken from test-12 with a little
extra head room.

Co-authored-by: rory malcolm
<rory.malcolm@digital.cabinet-office.gov.uk>

## WHAT ##
This has been applied first using snapshots taken from test-12 and the the `snapshot_identifier` removed from the config to prevent it rolling back each the terraform is run. Similar approach as per staging.