### PR TITLE
PP-7150: Web ACL Access Configuration

### DIFF
--- a/terraform/modules/aws/card-frontend.tf
+++ b/terraform/modules/aws/card-frontend.tf
@@ -71,7 +71,7 @@ resource "aws_cloudfront_distribution" "card_frontend" {
     ssl_support_method       = "sni-only"
   }
 
-  web_acl_id = aws_wafv2_web_acl.card_frontend.id
+  web_acl_id = aws_wafv2_web_acl.card_frontend.arn
 }
 
 data "pass_password" "card_frontend_pubkey" {
@@ -209,6 +209,7 @@ resource "aws_wafv2_web_acl" "card_frontend" {
 }
 
 resource "aws_wafv2_web_acl_logging_configuration" "card_frontend" {
+  provider                = aws.us
   log_destination_configs = [module.waf_logging.kinesis_stream_id]
   resource_arn            = aws_wafv2_web_acl.card_frontend.arn
   redacted_fields {

--- a/terraform/modules/aws/notifications.tf
+++ b/terraform/modules/aws/notifications.tf
@@ -69,7 +69,7 @@ resource "aws_cloudfront_distribution" "notifications" {
     ssl_support_method       = "sni-only"
   }
 
-  web_acl_id = aws_wafv2_web_acl.notifications.id
+  web_acl_id = aws_wafv2_web_acl.notifications.arn
 }
 
 resource "aws_wafv2_web_acl" "notifications" {
@@ -178,6 +178,7 @@ resource "aws_wafv2_web_acl" "notifications" {
 }
 
 resource "aws_wafv2_web_acl_logging_configuration" "notifications" {
+  provider                = aws.us
   log_destination_configs = [module.waf_logging.kinesis_stream_id]
   resource_arn            = aws_wafv2_web_acl.notifications.arn
 }

--- a/terraform/modules/aws/products-ui.tf
+++ b/terraform/modules/aws/products-ui.tf
@@ -69,7 +69,7 @@ resource "aws_cloudfront_distribution" "products_ui" {
     ssl_support_method       = "sni-only"
   }
 
-  web_acl_id = aws_wafv2_web_acl.products_ui.id
+  web_acl_id = aws_wafv2_web_acl.products_ui.arn
 }
 
 resource "aws_wafv2_web_acl" "products_ui" {
@@ -178,6 +178,7 @@ resource "aws_wafv2_web_acl" "products_ui" {
 }
 
 resource "aws_wafv2_web_acl_logging_configuration" "products_ui" {
+  provider                = aws.us
   log_destination_configs = [module.waf_logging.kinesis_stream_id]
   resource_arn            = aws_wafv2_web_acl.products_ui.arn
 }

--- a/terraform/modules/aws/publicapi.tf
+++ b/terraform/modules/aws/publicapi.tf
@@ -69,7 +69,7 @@ resource "aws_cloudfront_distribution" "publicapi" {
     ssl_support_method       = "sni-only"
   }
 
-  web_acl_id = aws_wafv2_web_acl.publicapi.id
+  web_acl_id = aws_wafv2_web_acl.publicapi.arn
 }
 
 resource "aws_wafv2_web_acl" "publicapi" {
@@ -182,6 +182,7 @@ resource "aws_wafv2_web_acl" "publicapi" {
 }
 
 resource "aws_wafv2_web_acl_logging_configuration" "publicapi" {
+  provider                = aws.us
   log_destination_configs = [module.waf_logging.kinesis_stream_id]
   resource_arn            = aws_wafv2_web_acl.publicapi.arn
   redacted_fields {

--- a/terraform/modules/aws/selfservice.tf
+++ b/terraform/modules/aws/selfservice.tf
@@ -69,7 +69,7 @@ resource "aws_cloudfront_distribution" "selfservice" {
     ssl_support_method       = "sni-only"
   }
 
-  web_acl_id = aws_wafv2_web_acl.selfservice.id
+  web_acl_id = aws_wafv2_web_acl.selfservice.arn
 }
 
 resource "aws_wafv2_web_acl" "selfservice" {
@@ -178,6 +178,7 @@ resource "aws_wafv2_web_acl" "selfservice" {
 }
 
 resource "aws_wafv2_web_acl_logging_configuration" "selfservice" {
+  provider                = aws.us
   log_destination_configs = [module.waf_logging.kinesis_stream_id]
   resource_arn            = aws_wafv2_web_acl.selfservice.arn
   redacted_fields {


### PR DESCRIPTION
`web_acl_id` property of an `aws_cloudfront_distribution` actually needs to be an ARN even though the docs state ID. https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#web_acl_id

`aws_wafv2_web_acl_logging_configuration` need to use the `us` (us-east-1) provider because they are "global" resources.