### PR TITLE
PP-7026 Add space to cardid data deployment

### DIFF
--- a/ci/pipelines/deploy.yml
+++ b/ci/pipelines/deploy.yml
@@ -739,11 +739,12 @@ jobs:
         trigger: true
       - task: deploy-to-paas-staging
         file: omnibus/ci/tasks/cf-v3-deploy.yml
+        input_mapping: { artefact: cardid-data-source }
         params:
-          <<: *cf-creds
+          <<: *app-deploy-config
           APP_NAME: cardid-data
-          APP_PATH: cardid-data-source/sources
-          MANIFEST: cardid-data-source/manifest.yml
+          APP_PATH: artefact/sources
+          MANIFEST: artefact/manifest.yml
           ZDT: true
 
   - name: deploy-cardid-staging

--- a/ci/pipelines/test-deploy.yml
+++ b/ci/pipelines/test-deploy.yml
@@ -298,11 +298,12 @@ jobs:
         trigger: true
       - task: deploy-to-paas-test
         file: omnibus/ci/tasks/cf-v3-deploy.yml
+        input_mapping: { artefact: cardid-data-source }
         params:
-          <<: *cf-creds
+          <<: *app-deploy-config
           APP_NAME: cardid-data
-          APP_PATH: cardid-data-source/sources
-          MANIFEST: cardid-data-source/manifest.yml
+          APP_PATH: artefact/sources
+          MANIFEST: artefact/manifest.yml
           ZDT: true
 
   - name: deploy-cardid-test


### PR DESCRIPTION
Possibly something changed since we last deployed it in April but need
to add the space and mapping from the `cardid-data` source to the
generic `artefact` directory which is used by the deploy script.

## WHAT ##
Sorts out deployment of cardid-data in test and staging. I've applied this and both successfully deploy, as do the corresponding cardid apps in both environments. 