### PR TITLE
PP-7027 Use bcrypt salt and hmac values from existing infra

### DIFF
--- a/terraform/staging-paas/terraform.tfvars
+++ b/terraform/staging-paas/terraform.tfvars
@@ -2,6 +2,7 @@ credentials = {
   publicapi = {
     pay_low_pass_secrets = {
       sentry_dsn = "sentry/publicapi_dsn"
+      token_api_hmac_secret = "paas/govuk-pay/staging/general/token_api_hmac_secret"
     }
     static_values = {
       rate_limiter_value               = "200"
@@ -12,7 +13,6 @@ credentials = {
       rate_limiter_elevated_accounts   = "31"
       rate_limiter_elevated_value_get  = "100"
       rate_limiter_elevated_value_post = "200"
-      token_api_hmac_secret            = "something"
     }
   }
   card_connector = {
@@ -61,11 +61,11 @@ credentials = {
     pay_low_pass_secrets = {
       sentry_dsn  = "sentry/publicauth_dsn"
       db_password = "aws/paas/staging/rds/application_users/publicauth/publicauth1"
+      token_db_bcrypt_salt  = "paas/govuk-pay/staging/publicauth/token_db_bcrypt_salt"
+      token_api_hmac_secret = "paas/govuk-pay/staging/general/token_api_hmac_secret"
     }
     static_values = {
       // @todo move these to secret store (placeholder for now)
-      token_db_bcrypt_salt  = "$2a$12$ZqrGf7v9uNXR6htsfz4k2u"
-      token_api_hmac_secret = "something"
       db_user               = "publicauth1"
       db_name               = "publicauth"
       db_ssl_option         = "true"

--- a/terraform/test-paas/terraform.tfvars
+++ b/terraform/test-paas/terraform.tfvars
@@ -5,6 +5,7 @@ credentials = {
   publicapi = {
     pay_low_pass_secrets = {
       sentry_dsn = "sentry/publicapi_dsn"
+      token_api_hmac_secret = "paas/govuk-pay/test/general/token_api_hmac_secret"
     }
     static_values = {
       rate_limiter_value               = "200"
@@ -15,7 +16,6 @@ credentials = {
       rate_limiter_elevated_accounts   = "31"
       rate_limiter_elevated_value_get  = "100"
       rate_limiter_elevated_value_post = "200"
-      token_api_hmac_secret            = "something"
     }
   }
   card_connector = {
@@ -64,11 +64,11 @@ credentials = {
     pay_low_pass_secrets = {
       sentry_dsn  = "sentry/publicauth_dsn"
       db_password = "aws/paas/test/rds/application_users/publicauth/publicauth1"
+      token_db_bcrypt_salt  = "paas/govuk-pay/test/publicauth/token_db_bcrypt_salt"
+      token_api_hmac_secret = "paas/govuk-pay/test/general/token_api_hmac_secret"
     }
     static_values = {
       // @todo move these to secret store (placeholder for now)
-      token_db_bcrypt_salt  = "$2a$12$ZqrGf7v9uNXR6htsfz4k2u"
-      token_api_hmac_secret = "something"
       db_user               = "publicauth1"
       db_name               = "publicauth"
       db_ssl_option         = "true"


### PR DESCRIPTION
To use API tokens that already existed within the copied RDS data from
test-12 or staging-2 we need to use the same bcrypt salt and hmac
values.