### PR TITLE
PP-7022 Fix can-i-deploy check

### DIFF
--- a/ci/docker/pact_with_jq/Dockerfile
+++ b/ci/docker/pact_with_jq/Dockerfile
@@ -1,0 +1,2 @@
+FROM pactfoundation/pact-cli
+RUN apk add jq

--- a/ci/tasks/pact-provider-test-preflight-check.yml
+++ b/ci/tasks/pact-provider-test-preflight-check.yml
@@ -2,7 +2,7 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: pactfoundation/pact-cli
+    repository: govukpay/pact_with_jq
 params:
   consumer:
   broker_username: ((pact-broker-username))
@@ -26,7 +26,8 @@ run:
             --pacticipant="$consumer" --version="$git_sha" \
             --broker_base_url="$broker_url" \
             --broker-username="$broker_username" \
-            --broker-password="$broker_password")"
+            --broker-password="$broker_password" \
+            --output=json)"
           return $?
       }
 
@@ -47,7 +48,7 @@ run:
         echo "Providers needing verification: "
         touch pact_params/providers_needing_verification
         echo "$can_deploy" | \
-          awk 'BEGIN {FS="|"}; /\|/ && NR > 4 && !/true/{print $3}' | \
+          jq '.matrix[] | select(.verificationResult.success != true) | .provider.name' | \
           tr -d ' ' | \
           tee pact_params/providers_needing_verification
 


### PR DESCRIPTION
Switch to `json` output which is easier to parse. The preivous logic was
not correctly identifying providers that required validation when they
had not yet been validated against the version of the contract in the
request. This uses a new container which adds `jq` to the
`pactfoundation/pact-cli` image we were already using.

## WHAT ##
Previous we were parsing the `can-i-deploy` table response with `awk`, we didn't know `json` format was available. This hopefully makes it clearer and correctly identifies cases when provider validation is required.

The bug in this script is mitigated because Jenkins has been running pact validation on main builds.

I have built and pushed the `govukpay/pact_with_jq` image to dockerhub: https://hub.docker.com/repository/docker/govukpay/pact_with_jq

Tested the `jq` with recent pr which highlighted this issue: https://github.com/alphagov/pay-publicapi/pull/1008
```
/pact # echo "$can_deploy" | jq '.matrix[] | select(.verificationResult.success != true) | .provider.name'
"ledger"
```
