### PR TITLE
PP-7021 Create paas test releases

### DIFF
--- a/ci/pipelines/test-deploy.yml
+++ b/ci/pipelines/test-deploy.yml
@@ -9,8 +9,8 @@ definitions:
       METRIC_NAME: change-this-value
       METRIC_VALUE: 0
 
-  - &create-release-metatdata
-    task: create-release-metatdata
+  - &create-release-metadata
+    task: create-release-metadata
     config:
       platform: linux
       image_resource:
@@ -832,7 +832,7 @@ jobs:
         resource: git-adminusers-pre-release
         trigger: true
         passed: [card-payment-smoke-tests-test]
-      - <<: *create-release-metatdata
+      - <<: *create-release-metadata
       - <<: *create-test-release
         resource: git-adminusers-pre-release
 
@@ -842,7 +842,7 @@ jobs:
         resource: git-card-frontend-pre-release
         trigger: true
         passed: [card-payment-smoke-tests-test]
-      - <<: *create-release-metatdata
+      - <<: *create-release-metadata
       - <<: *create-test-release
         resource: git-card-frontend-pre-release
 
@@ -852,7 +852,7 @@ jobs:
         resource: git-selfservice-pre-release
         trigger: true
         passed: [deploy-selfservice-test]
-      - <<: *create-release-metatdata
+      - <<: *create-release-metadata
       - <<: *create-test-release
         resource: git-selfservice-pre-release
 
@@ -862,7 +862,7 @@ jobs:
         resource: git-products-ui-pre-release
         trigger: true
         passed: [products-smoke-test-test]
-      - <<: *create-release-metatdata
+      - <<: *create-release-metadata
       - <<: *create-test-release
         resource: git-products-ui-pre-release
 
@@ -872,7 +872,7 @@ jobs:
         resource: git-card-connector-pre-release
         trigger: true
         passed: [card-payment-smoke-tests-test]
-      - <<: *create-release-metatdata
+      - <<: *create-release-metadata
       - <<: *create-test-release
         resource: git-card-connector-pre-release
 
@@ -882,7 +882,7 @@ jobs:
         resource: git-publicauth-pre-release
         trigger: true
         passed: [card-payment-smoke-tests-test]
-      - <<: *create-release-metatdata
+      - <<: *create-release-metadata
       - <<: *create-test-release
         resource: git-publicauth-pre-release
 
@@ -892,7 +892,7 @@ jobs:
         resource: git-publicapi-pre-release
         trigger: true
         passed: [card-payment-smoke-tests-test]
-      - <<: *create-release-metatdata
+      - <<: *create-release-metadata
       - <<: *create-test-release
         resource: git-publicapi-pre-release
 
@@ -902,7 +902,7 @@ jobs:
         resource: git-cardid-pre-release
         trigger: true
         passed: [card-payment-smoke-tests-test]
-      - <<: *create-release-metatdata
+      - <<: *create-release-metadata
       - <<: *create-test-release
         resource: git-cardid-pre-release
 
@@ -912,7 +912,7 @@ jobs:
         resource: git-ledger-pre-release
         trigger: true
         passed: [card-payment-smoke-tests-test]
-      - <<: *create-release-metatdata
+      - <<: *create-release-metadata
       - <<: *create-test-release
         resource: git-ledger-pre-release
 
@@ -922,7 +922,7 @@ jobs:
         resource: git-products-pre-release
         trigger: true
         passed: [products-smoke-test-test]
-      - <<: *create-release-metatdata
+      - <<: *create-release-metadata
       - <<: *create-test-release
         resource: git-products-pre-release
 
@@ -932,6 +932,6 @@ jobs:
         resource: git-toolbox-pre-release
         trigger: true
         passed: [deploy-toolbox-test]
-      - <<: *create-release-metatdata
+      - <<: *create-release-metadata
       - <<: *create-test-release
         resource: git-toolbox-pre-release

--- a/ci/pipelines/test-deploy.yml
+++ b/ci/pipelines/test-deploy.yml
@@ -55,51 +55,61 @@ groups:
       - deploy-card-connector-test
       - migrate-card-connector-db-test
       - card-payment-smoke-tests-test
+      - create-card-connector-test-release
 
   - name: card-id
     jobs:
       - deploy-cardid-test
       - deploy-cardid-data-test
       - card-payment-smoke-tests-test
+      - create-cardid-test-release
 
   - name: card-frontend
     jobs:
       - deploy-card-frontend-test
       - card-payment-smoke-tests-test
+      - create-card-frontend-test-release
 
   - name: ledger
     jobs:
       - deploy-ledger-test
       - migrate-ledger-db-test
       - card-payment-smoke-tests-test
+      - create-ledger-test-release
 
   - name: products
     jobs:
       - deploy-products-test
       - migrate-products-db-test
       - products-smoke-test-test
+      - create-products-test-release
 
   - name: products-ui
     jobs:
       - deploy-products-ui-test
       - products-smoke-test-test
+      - create-products-ui-test-release
 
   - name: public-api
     jobs:
       - deploy-publicapi-test
       - card-payment-smoke-tests-test
+      - create-publicapi-test-release
 
   - name: publicauth
     jobs:
       - deploy-publicauth-test
       - migrate-publicauth-db-test
       - card-payment-smoke-tests-test
+      - create-publicauth-test-release
 
   - name: other-services
     jobs:
       - deploy-selfservice-test
+      - create-selfservice-test-release
       - deploy-notifications-test
       - deploy-toolbox-test
+      - create-toolbox-test-release
       - deploy-sqs-test
       - update-deploy-pipeline
 
@@ -826,3 +836,102 @@ jobs:
       - <<: *create-test-release
         resource: git-adminusers-pre-release
 
+  - name: create-card-frontend-test-release
+    plan:
+      - get: pre-release
+        resource: git-card-frontend-pre-release
+        trigger: true
+        passed: [card-payment-smoke-tests-test]
+      - <<: *create-release-metatdata
+      - <<: *create-test-release
+        resource: git-card-frontend-pre-release
+
+  - name: create-selfservice-test-release
+    plan:
+      - get: pre-release
+        resource: git-selfservice-pre-release
+        trigger: true
+        passed: [deploy-selfservice-test]
+      - <<: *create-release-metatdata
+      - <<: *create-test-release
+        resource: git-selfservice-pre-release
+
+  - name: create-products-ui-test-release
+    plan:
+      - get: pre-release
+        resource: git-products-ui-pre-release
+        trigger: true
+        passed: [products-smoke-test-test]
+      - <<: *create-release-metatdata
+      - <<: *create-test-release
+        resource: git-products-ui-pre-release
+
+  - name: create-card-connector-test-release
+    plan:
+      - get: pre-release
+        resource: git-card-connector-pre-release
+        trigger: true
+        passed: [card-payment-smoke-tests-test]
+      - <<: *create-release-metatdata
+      - <<: *create-test-release
+        resource: git-card-connector-pre-release
+
+  - name: create-publicauth-test-release
+    plan:
+      - get: pre-release
+        resource: git-publicauth-pre-release
+        trigger: true
+        passed: [card-payment-smoke-tests-test]
+      - <<: *create-release-metatdata
+      - <<: *create-test-release
+        resource: git-publicauth-pre-release
+
+  - name: create-publicapi-test-release
+    plan:
+      - get: pre-release
+        resource: git-publicapi-pre-release
+        trigger: true
+        passed: [card-payment-smoke-tests-test]
+      - <<: *create-release-metatdata
+      - <<: *create-test-release
+        resource: git-publicapi-pre-release
+
+  - name: create-cardid-test-release
+    plan:
+      - get: pre-release
+        resource: git-cardid-pre-release
+        trigger: true
+        passed: [card-payment-smoke-tests-test]
+      - <<: *create-release-metatdata
+      - <<: *create-test-release
+        resource: git-cardid-pre-release
+
+  - name: create-ledger-test-release
+    plan:
+      - get: pre-release
+        resource: git-ledger-pre-release
+        trigger: true
+        passed: [card-payment-smoke-tests-test]
+      - <<: *create-release-metatdata
+      - <<: *create-test-release
+        resource: git-ledger-pre-release
+
+  - name: create-products-test-release
+    plan:
+      - get: pre-release
+        resource: git-products-pre-release
+        trigger: true
+        passed: [products-smoke-test-test]
+      - <<: *create-release-metatdata
+      - <<: *create-test-release
+        resource: git-products-pre-release
+
+  - name: create-toolbox-test-release
+    plan:
+      - get: pre-release
+        resource: git-toolbox-pre-release
+        trigger: true
+        passed: [deploy-toolbox-test]
+      - <<: *create-release-metatdata
+      - <<: *create-test-release
+        resource: git-toolbox-pre-release

--- a/ci/pipelines/test-deploy.yml
+++ b/ci/pipelines/test-deploy.yml
@@ -8,12 +8,47 @@ definitions:
       HOSTED_GRAPHITE_API_KEY: change-this-value
       METRIC_NAME: change-this-value
       METRIC_VALUE: 0
+
+  - &create-release-metatdata
+    task: create-release-metatdata
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: govukpay/concourse-runner
+      inputs:
+        - name: pre-release
+      params:
+        ENVIRONMENT: test
+      outputs:
+        - name: release-metadata
+      run:
+        path: bash
+        args:
+          - -ec
+          - |
+            release_number="$(grep -oe "\d\+$" pre-release/tag)"
+            release_name="paas_release_${ENVIRONMENT}-${release_number}"
+            echo "$release_name" | tee release-metadata/tag
+
+  - &create-test-release
+    put: release
+    resource: update-this-value
+    params:
+      name: release-metadata/tag
+      tag: release-metadata/tag
+      globs:
+        - pre-release/pay-*
+      commitish: pre-release/commit_sha
+
 groups:
   - name: adminusers
     jobs:
       - deploy-adminusers-test
       - migrate-adminusers-db-test
       - card-payment-smoke-tests-test
+      - create-adminusers-test-release
 
   - name: card-connector
     jobs:
@@ -779,4 +814,15 @@ jobs:
           <<: *migration-params
           APP_NAME: publicauth
           APP_PACKAGE: uk.gov.pay.publicauth.app.PublicAuthApp
+
+  # Create git release with tag "test"
+  - name: create-adminusers-test-release
+    plan:
+      - get: pre-release
+        resource: git-adminusers-pre-release
+        trigger: true
+        passed: [card-payment-smoke-tests-test]
+      - <<: *create-release-metatdata
+      - <<: *create-test-release
+        resource: git-adminusers-pre-release
 


### PR DESCRIPTION
After a pre-release with the tag format `paas_release-n` has been
deployed and the smoke tests have passed, create a pre-release with the tag
`paas_release_test-n` which can then be deployed into staging.

This is just for Adminusers and will apply the same to the other apps if
we agree on this approach.

## WHAT ##
As described above. I've tested this out and the resulting pre-release is here: 
https://github.com/alphagov/pay-adminusers/releases/tag/paas_release_test-62
