### PR TITLE
PP-7027 Remove smoke test user setup

### DIFF
--- a/ci/pipelines/deploy.yml
+++ b/ci/pipelines/deploy.yml
@@ -111,7 +111,6 @@ groups:
       - deploy-selenium-hub
       - deploy-smoke-tests-staging
       - smoke-tests-staging-network-policies
-      - smoke-test-user-staging
       - card-payment-smoke-tests-staging
       - products-smoke-test-staging
 
@@ -1051,29 +1050,6 @@ jobs:
           port: 4444
           protocol: tcp
 
-  - name: smoke-test-user-staging
-    serial_groups:
-      - card-connector-stg
-      - publicapi-stg
-      - publicauth-stg
-      - adminusers-stg
-      - products-stg
-      - smoke-tests-stg
-    plan:
-      - get: omnibus
-      - get: endtoend-container
-        passed: [deploy-smoke-tests-staging]
-        trigger: true
-      - task: create-service
-        file: omnibus/ci/tasks/smoke-test-user.yml
-        params:
-          <<: *cf-creds
-          CF_SPACE: staging
-          CF_SPACE_CDE: staging-cde
-          CF_SPACE_TOOLS: smoke-tests
-          SMOKE_TEST_APP: smoke-tests-staging
-          SERVICE_NAME: smoke-test-user-staging
-
   - name: card-payment-smoke-tests-staging
     serial_groups: [cardid-stg, card-connector-stg, card-frontend-stg, ledger-stg, publicapi-stg, publicauth-stg]
     build_log_retention:
@@ -1081,7 +1057,7 @@ jobs:
     plan:
       - get: omnibus
       - get: endtoend-container
-        passed: [deploy-smoke-tests-staging, smoke-test-user-staging]
+        passed: [deploy-smoke-tests-staging]
         trigger: true
       - get: every-10-minutes
         trigger: true
@@ -1147,7 +1123,7 @@ jobs:
     plan:
       - get: omnibus
       - get: endtoend-container
-        passed: [deploy-smoke-tests-staging, smoke-test-user-staging]
+        passed: [deploy-smoke-tests-staging]
         trigger: true
       - get: every-10-minutes
         trigger: true

--- a/ci/pipelines/test-deploy.yml
+++ b/ci/pipelines/test-deploy.yml
@@ -73,7 +73,6 @@ groups:
       - deploy-selenium-hub
       - deploy-smoke-tests-test
       - smoke-tests-test-network-policies
-      - smoke-test-user-test
       - card-payment-smoke-tests-test
       - products-smoke-test-test
 
@@ -600,29 +599,6 @@ jobs:
           port: 4444
           protocol: tcp
 
-  - name: smoke-test-user-test
-    serial_groups:
-      - card-connector
-      - publicapi
-      - publicauth
-      - adminusers
-      - products
-      - smoke-tests
-    plan:
-      - get: omnibus
-      - get: endtoend-container
-        passed: [deploy-smoke-tests-test]
-        trigger: true
-      - task: create-service
-        file: omnibus/ci/tasks/smoke-test-user.yml
-        params:
-          <<: *cf-creds
-          CF_SPACE: test
-          CF_SPACE_CDE: test-cde
-          CF_SPACE_TOOLS: smoke-tests
-          SMOKE_TEST_APP: smoke-tests-test
-          SERVICE_NAME: smoke-test-user-test
-
   - name: card-payment-smoke-tests-test
     serial_groups: [cardid, card-connector, card-frontend, ledger, publicapi, publicauth]
     build_log_retention:
@@ -630,7 +606,7 @@ jobs:
     plan:
       - get: omnibus
       - get: endtoend-container
-        passed: [deploy-smoke-tests-test, smoke-test-user-test]
+        passed: [deploy-smoke-tests-test]
         trigger: true
       - get: every-10-minutes
         trigger: true
@@ -696,7 +672,7 @@ jobs:
     plan:
       - get: omnibus
       - get: endtoend-container
-        passed: [deploy-smoke-tests-test, smoke-test-user-test]
+        passed: [deploy-smoke-tests-test]
         trigger: true
       - get: every-10-minutes
         trigger: true

--- a/ci/scripts/setup_smoke_tests.sh
+++ b/ci/scripts/setup_smoke_tests.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Simple helper script to set the env vars for the smoke test app which is
+# done infrequently.
+
+# enable the use of `pay-low-pass` alias.
+shopt -s expand_aliases
+source ~/.bash_profile
+
+ENVIRONMENT="${1:?Provide environment: test|staging}"
+
+echo "switching to 'smoke-tests' space"
+cf t -s smoke-tests
+
+cf set-env smoke-tests-"$ENVIRONMENT" SELFSERVICE_OTP_KEY "$(pay-low-pass smoke-test-users/sandbox/otp-token)"
+
+cf set-env smoke-tests-"$ENVIRONMENT" SELFSERVICE_PASSWORD "$(pay-low-pass smoke-test-users/sandbox/password)"
+
+cf set-env smoke-tests-"$ENVIRONMENT" SELFSERVICE_USERNAME "$(pay-low-pass smoke-test-users/sandbox/username)"
+
+cf set-env smoke-tests-"$ENVIRONMENT" SMOKE_TEST_PRODUCT_PAYMENT_LINK_URL "https://products.${ENVIRONMENT}.gdspay.uk/redirect/smoke-tests-sandbox/products-sandbox-smoke-tests"
+
+echo "Now create an api token via selfservice and set it with:"
+echo "cf set-env smoke-tests-${ENVIRONMENT} CARD_SANDBOX_API_TOKEN <token>"
+
+echo "now restage smoke-tests-${ENVIRONMENT}"
+


### PR DESCRIPTION
In the early days of the PaaS migration we used a bit of the `pay local`
cli to create a user to be used for the sandbox smoke tests. Now we are
using snapshots of RDS instances from our existing environments e.g.
`test-12` we want to use the existing smoke test services and accounts.

Therefore remove the concourse job that would create a new smoke test
user and add a simple script to help set the necessary values.
