### PR TITLE
PP-7213 Run lint checks on node prs

### DIFF
--- a/ci/tasks/node-build-pr.yml
+++ b/ci/tasks/node-build-pr.yml
@@ -43,6 +43,7 @@ run:
       if [ "$skip_tests" = true ]; then
         echo "Skipping tests"
       else
+        npm run lint
         npm test -- --forbid-only --forbid-pending
 
         if [ -f "cypress.json" ]; then


### PR DESCRIPTION
We run each node app's lint script on Jenkins and we should do the same
on Concourse.

## WHAT ##
`npm run lint` is run on Jenkins via each app's `build_and_test.sh` script:
```
grep "npm run lint" pay-*/docker/build_and_test.sh                                                             
pay-direct-debit-frontend/docker/build_and_test.sh:npm run lint &&\
pay-frontend/docker/build_and_test.sh:npm run lint
pay-products-ui/docker/build_and_test.sh:npm run lint
pay-selfservice/docker/build_and_test.sh:npm run lint
```
toolbox is built differently but also includes a `lint` script in it's `package.json`:
```
pay-toolbox/package.json -- lint script --> "eslint "src/**/*.{js,ts,tsx}""
```

On the Concourse pr pipeline we test each of those node apps using `node-build-pr.yml` which is modified herein to add `npm run lint`
```
 grep -B 1 "\*node-test" pay-omnibus/ci/pipelines/pr.yml
      put: card-frontend-pull-request
    - <<: *node-test
--
      put: selfservice-pull-request
    - <<: *node-test
--
      put: toolbox-pull-request
    - <<: *node-test
--
      put: products-ui-pull-request
    - <<: *node-test
--
      put: directdebit-frontend-pull-request
    - <<: *node-test

```