### PR TITLE
PP-7026 Fix deployment of metric-exporter

### DIFF
--- a/ci/pipelines/deploy.yml
+++ b/ci/pipelines/deploy.yml
@@ -1000,10 +1000,10 @@ jobs:
         input_mapping: { artefact: "metric-exporter-source" }
         params:
           <<: *app-deploy-config
-          APP_NAME: metric-exporter          
+          APP_NAME: metric-exporter
           CF_SPACE: staging
           MANIFEST: omnibus/paas/metric-exporter/manifest.yml
-          APP_PATH: metric-exporter-source
+          APP_PATH: artefact
 
   # Smoke Tests
   - name: deploy-selenium-hub

--- a/ci/pipelines/test-deploy.yml
+++ b/ci/pipelines/test-deploy.yml
@@ -597,7 +597,7 @@ jobs:
           APP_NAME: metric-exporter
           CF_SPACE: test
           MANIFEST: omnibus/paas/metric-exporter/manifest.yml
-          APP_PATH: metric-exporter-source
+          APP_PATH: artefact
 
   # Smoke Tests
   - name: deploy-selenium-hub


### PR DESCRIPTION
Seems the pipeline has moved on since it was last deployed and the
config needs updating to correctly reference the location of the files
to push.

Updated for test and staging environments.

## WHAT ##
Deploying the `metric-exporter` was broken because the app's file location was incorrect, see error in logs: https://cd.gds-reliability.engineering/teams/pay-dev/pipelines/test-deploy/jobs/deploy-metric-exporter-test/builds/2#L5f6c2627:17
```
Incorrect Usage: The specified path '/tmp/build/1cd06cbc/metric-exporter-source' does not exist.
```

This fixes it so it now deploys correctly: https://cd.gds-reliability.engineering/teams/pay-dev/pipelines/test-deploy/jobs/deploy-metric-exporter-test/builds/2.1

Anyone wondering this fixes it, it's because the input mapping renames the directory given as the value to the name of the key, hence the directory will be available to the job as `artefact` and not `metrix-exporter-source`. 
```
input_mapping: { artefact: "metric-exporter-source" }
```
The `input-mapping` is used so that the task `cf-v3-deploy.yml` can be  generalised to work an input directory named `artefact`. https://github.com/alphagov/pay-omnibus/blob/0fe917a2121935d2952a7a27db6ec7994bb38eac/ci/tasks/cf-v3-deploy.yml#L12
