### PR TITLE
Pp 7121 create main build pipeline

### DIFF
--- a/ci/pipelines/deploy.yml
+++ b/ci/pipelines/deploy.yml
@@ -732,31 +732,6 @@ jobs:
       - task: extract-card-connector-artefact
         file: omnibus/ci/tasks/extract-artefact.yml
         input_mapping: { git-release: git-card-connector-pre-release }
-      - in_parallel:
-        - <<: *verify-provider-with-consumer
-          task: verify-with-publicapi
-          input_mapping: {src: extract-card-connector-artefact}
-          params:
-            consumer: publicapi
-            provider: connector
-        - <<: *verify-provider-with-consumer
-          task: verify-with-frontend
-          input_mapping: {src: extract-card-connector-artefact}
-          params:
-            consumer: frontend
-            provider: connector
-        - <<: *verify-provider-with-consumer
-          task: verify-with-selfservice
-          input_mapping: {src: extract-card-connector-artefact}
-          params:
-            consumer: selfservice
-            provider: connector
-        - <<: *verify-provider-with-consumer
-          task: verify-with-ledger
-          input_mapping: {src: extract-card-connector-artefact}
-          params:
-            consumer: ledger
-            provider: connector
       - task: deploy-to-paas-staging
         file: omnibus/ci/tasks/cf-v3-deploy.yml
         params:

--- a/ci/pipelines/deploy.yml
+++ b/ci/pipelines/deploy.yml
@@ -37,7 +37,6 @@ groups:
 
   - name: Card Connector
     jobs:
-      - build-card-connector
       - deploy-card-connector-staging
       - migrate-card-connector-db-staging
       - card-payment-smoke-tests-staging
@@ -219,12 +218,6 @@ resources:
       uri: https://github.com/alphagov/pay-direct-debit-connector
 
   - <<: *git-repo
-    name: card-connector-source
-    source:
-      <<: *git-repo-source
-      uri: https://github.com/alphagov/pay-connector
-
-  - <<: *git-repo
     name: publicapi-source
     source:
       <<: *git-repo-source
@@ -301,6 +294,7 @@ resources:
     source:
       <<: *github-release-source
       repository: pay-connector
+      tag_filter: "paas_release_test-(.*)"
 
   - name: git-publicauth-pre-release
     type: github-release
@@ -521,44 +515,6 @@ jobs:
         params: 
           <<: *release-params
 
-  - name: build-card-connector
-    plan:
-      - get: omnibus
-      - get: src
-        resource: card-connector-source
-        trigger: true
-      - in_parallel:
-        - <<: *verify-provider-with-consumer
-          task: verify-with-publicapi
-          params:
-            consumer: publicapi
-            provider: connector
-        - <<: *verify-provider-with-consumer
-          task: verify-with-frontend
-          params:
-            consumer: frontend
-            provider: connector
-        - <<: *verify-provider-with-consumer
-          task: verify-with-selfservice
-          params:
-            consumer: selfservice
-            provider: connector
-        - <<: *verify-provider-with-consumer
-          task: verify-with-ledger
-          params:
-            consumer: ledger
-            provider: connector
-      - task: calculate-release-number
-        file: omnibus/ci/tasks/calculate-release-number.yml
-      - task: build-app
-        file: omnibus/ci/tasks/maven-build.yml
-        params:
-          APP_NAME: pay-connector
-      - put: release
-        resource: git-card-connector-pre-release
-        params: 
-          <<: *release-params
-
   - name: build-publicapi
     plan:
       - get: omnibus
@@ -772,11 +728,35 @@ jobs:
     plan:
       - get: omnibus
       - get: git-card-connector-pre-release
-        passed: [build-card-connector]
         trigger: true
       - task: extract-card-connector-artefact
         file: omnibus/ci/tasks/extract-artefact.yml
         input_mapping: { git-release: git-card-connector-pre-release }
+      - in_parallel:
+        - <<: *verify-provider-with-consumer
+          task: verify-with-publicapi
+          input_mapping: {src: extract-card-connector-artefact}
+          params:
+            consumer: publicapi
+            provider: connector
+        - <<: *verify-provider-with-consumer
+          task: verify-with-frontend
+          input_mapping: {src: extract-card-connector-artefact}
+          params:
+            consumer: frontend
+            provider: connector
+        - <<: *verify-provider-with-consumer
+          task: verify-with-selfservice
+          input_mapping: {src: extract-card-connector-artefact}
+          params:
+            consumer: selfservice
+            provider: connector
+        - <<: *verify-provider-with-consumer
+          task: verify-with-ledger
+          input_mapping: {src: extract-card-connector-artefact}
+          params:
+            consumer: ledger
+            provider: connector
       - task: deploy-to-paas-staging
         file: omnibus/ci/tasks/cf-v3-deploy.yml
         params:

--- a/ci/pipelines/main.yml
+++ b/ci/pipelines/main.yml
@@ -1,0 +1,76 @@
+definitions:
+  - &job-definition
+    name: updateThisValue
+    serial: true
+    build_log_retention:
+      builds: 500
+
+  - &github-release-source
+    source:
+      owner: alphagov
+      access_token: ((github-access-token))
+      tag_filter: "paas_release-(.*)"
+      order_by: version
+      repository: update-this-value
+      pre_release: true
+      release: false
+
+  - &release-params
+    params:
+      name: release-info/name
+      tag: release-info/name
+      globs:
+        - build-output/*
+      commitish: src/.git/ref
+
+groups:
+  - name: card-connector
+    jobs:
+      - build-card-connector
+
+resource_types:
+  - name: pull-request
+    type: registry-image
+    source:
+      repository: teliaoss/github-pr-resource
+      tag: dev
+
+resources:
+  - name: card-connector-main
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/alphagov/pay-connector
+      branch: master
+  - name: git-card-connector-pre-release
+    type: github-release
+    source:
+      <<: *github-release-source
+      repository: pay-connector
+  - name: omnibus
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/alphagov/pay-omnibus
+      branch: master
+      username: alphagov-pay-ci
+      password: ((github-access-token))
+
+jobs:
+  - <<: *job-definition
+    name: build-card-connector
+    plan:
+      - get: omnibus
+      - get: src
+        resource: card-connector-main
+        trigger: true
+      - task: calculate-release-number
+        file: omnibus/ci/tasks/calculate-release-number.yml
+      - task: build-app
+        file: omnibus/ci/tasks/maven-build.yml
+        params:
+          APP_NAME: pay-connector
+      - put: release
+        resource: git-card-connector-pre-release
+        params:
+          <<: *release-params


### PR DESCRIPTION
Initial work on adding main pipeline to build and create github
releases destined for paas. For the time being Jenkins will continue to run the tests on
the main branch and this pipeline will not; we may want to run the pact
tests because we're using separate brokers and `can-i-deploy` checks will be much
more complicated if we don't. Later work will migrate the testing from
Jenkins to this pipeline.

Changes included here:
- Build connector when a commit to main branch is made
- Create and upload github pre-release tagged `paas_release-n`
- Remove building of connector release from existing `deploy` pipeline
- Trigger the deployment of connector into staging via a release tagged
  with `paas_release_test-n` which is created via the
  `pay-dev/test-deploy` pipeline.

## WHAT ##
This is almost identical to the previously approved PR which I closed whilst we'd postponed this work. The only change is that `pay-deploy/deploy` for connector is triggered by a test pre-release tagged `paas_release_test-n` since that work is now complete: 
https://github.com/alphagov/pay-omnibus/pull/304

Remove pact validation prior to deployment since:
```
PP-7121 Remove pact validation prior to deployment

This is temporary. Whilst we're not running the pact tests on a merge to
the main branch on concourse the concourse pact
broker does not have a reference to the main branch merge commit of the
consumer or provider- only that of the PR head commit which was tested on the pr
pipeline.

When we deploy a consumer we need to tag it's pacts with the environment
which is used in `can-i-deploy` checks. When we get the git release to
deploy we only know the main branch merge commit it is associated with.
The pact broker does not have any reference to this so we cannot make a
call to add the environment tag to that unknown version of the consumer.
Similarly this impacts providers because although the PR commit sha will
have been recorded as validated during the PR build, the merge commit sha will
not and the validation would have to be needlessly run a again on deployment.

The solution is to run the pact broker validation and push contracts to the
pact broker when building the main branch on `pay-dev/main` which will be done
at a later date. Once that is done we can re-instate tagging consumer pacts and
provider versions upon deployment which will permit `can-i-deploy`
checks.

The work to reinstate this is captured in jira epic PP-7204
https://payments-platform.atlassian.net/browse/PP-7204
```