### PR TITLE
PP-7213 Run Publicapi's provider verification after its pushed pacts

### DIFF
--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -947,7 +947,7 @@ jobs:
     plan:
       - <<: *get-pull-request
         resource: publicapi-pull-request
-        passed: [publicapi-unit-test]
+        passed: [publicapi-unit-test, publicapi-integration-test]
       - <<: *put-pact-provider-pending-status
         put: publicapi-pull-request
       - <<: *get-omnibus
@@ -1315,7 +1315,6 @@ jobs:
     - <<: *put-integration-test-success-status
       put: ledger-pull-request
 
-      
   - <<: *job-definition
     name: ledger-pact-provider-test
     serial_groups: [pact-test]


### PR DESCRIPTION
Publiapi is a java consumer. This change ensures that its provider
verification (where we run it's associated providers against it's latest
contracts) happens after it's pushed the latest contracts as part of the
`publicapi-integration-test` job.

with @SandorArpa

## WHAT ##
I don't think the other apps need to change. the node consumers push their pacts as part of their `test` job which is already a prerequisite for the pact verification. Ledger is more complicated being both consumer and provider and it's pipeline looks fine.

You can see the relationships here: https://pay-concourse-pact-broker.cloudapps.digital/