### PR TITLE
PP-7121 Tag connector pacts with main

### DIFF
--- a/ci/pipelines/main.yml
+++ b/ci/pipelines/main.yml
@@ -23,6 +23,16 @@ definitions:
         - build-output/*
       commitish: src/.git/ref
 
+  - &tag-pacts-with-main
+    task: tag-pacts-with-main
+    file: omnibus/ci/tasks/tag-pacts.yml
+    vars:
+      pact-broker-username: ((pact-broker-username))
+      pact-broker-password: ((pact-broker-password))
+    params:
+      tag: main
+      consumer_name: change-this-value
+
 groups:
   - name: card-connector
     jobs:
@@ -64,6 +74,10 @@ jobs:
       - get: src
         resource: card-connector-main
         trigger: true
+      - <<: *tag-pacts-with-main
+        params:
+          tag: main
+          consumer_name: connector
       - task: calculate-release-number
         file: omnibus/ci/tasks/calculate-release-number.yml
       - task: build-app


### PR DESCRIPTION
When we build connector after a merge to the main branch tag the pacts
for that version of connector with `main`.

This is new since Connector has just become a consumer.

## WHAT ##
Applied this to main pipeline and it works as expected, here are the connector contracts tagged with `main`
https://pay-concourse-pact-broker.cloudapps.digital/hal-browser/browser.html#/pacticipants/connector/versions/074423d2109c1575b918e122d5a4f1a9cfd3ddf6