### PR TITLE
PP-7253 Validate pacts against consumers with main tag

### DIFF
--- a/ci/tasks/pact-provider-test-preflight-check.yml
+++ b/ci/tasks/pact-provider-test-preflight-check.yml
@@ -34,7 +34,7 @@ run:
 
       if [[ -z "$consumer" || "$consumer" == null ]]; then
         echo "Pact tests being run in provider context. Creating parameters..."
-        echo master > pact_params/consumer_tag
+        echo main > pact_params/consumer_tag
         touch pact_params/verification_needed
       else
 


### PR DESCRIPTION
We are now tagging pacts for commits when they have been merged to master with the "main" tag rather than "master". Update PRs to ensure we are validating providers against the correct consumer version.