### PR TITLE
We were using the 'dev' tag for the pr resource

### DIFF
--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -457,7 +457,7 @@ resource_types:
     type: registry-image
     source:
       repository: teliaoss/github-pr-resource
-      tag: dev
+      tag: latest
 
   - name: paas-s3
     type: registry-image


### PR DESCRIPTION
Use the 'latest' tag image rather than 'dev'. I think we experimented
with the 'dev' tag because it had some functionality we were exploring
during the development. I don't think we're reliant upon it now, but the
'dev' tag is broken so we need to move from it.

## WHAT ##
Applied to concourse and this resolves the pr resource errors we suddenly started to see. 