### PR TITLE
PP-6761 Downgrade Concourse Github PR Resource

### DIFF
--- a/ci/pipelines/main.yml
+++ b/ci/pipelines/main.yml
@@ -43,7 +43,7 @@ resource_types:
     type: registry-image
     source:
       repository: teliaoss/github-pr-resource
-      tag: dev
+      tag: v0.21.0
 
 resources:
   - name: card-connector-main

--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -457,7 +457,7 @@ resource_types:
     type: registry-image
     source:
       repository: teliaoss/github-pr-resource
-      tag: latest
+      tag: v0.21.0
 
   - name: paas-s3
     type: registry-image


### PR DESCRIPTION
- Downgrade the version of the Concourse Github PR Resource to see if it
is in fact new changes introduced to the resource check regarding PR
filtering that is causing the rate limiting error we are seeing.
